### PR TITLE
fix(frontend): Move Mapbox CSS import to global layout

### DIFF
--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { GoogleAnalytics, PageViewTracker } from "@/shared/lib";
 
 import { Providers } from "./providers";
 import "./globals.css";
+import "mapbox-gl/dist/mapbox-gl.css";
 
 /**
  * サイト全体のメタデータ

--- a/apps/frontend/src/shared/ui/mapbox/mapbox.tsx
+++ b/apps/frontend/src/shared/ui/mapbox/mapbox.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import "mapbox-gl/dist/mapbox-gl.css";
-
 import type { Map as MapboxGLMap } from "mapbox-gl";
 import { useEffect, useState } from "react";
 import type {


### PR DESCRIPTION
- Move mapbox-gl.css import from Mapbox component to app/layout.tsx
- Ensures CSS is loaded correctly in production (Cloudflare Workers)
- Fixes map rendering issue in admin/gallery/new page

🤖 Generated with [Claude Code](https://claude.com/claude-code)