### PR TITLE
fix(ci): Use CLOUDFLARE_ENV environment variable for Wrangler deployment

### DIFF
--- a/.github/workflows/_deploy-web.yml
+++ b/.github/workflows/_deploy-web.yml
@@ -83,7 +83,7 @@ jobs:
           export $(cat .env | xargs)
 
           # Cloudflare Workersにデプロイ（環境変数を渡す）
-          npx wrangler deploy --env ${{ env.ENV }} \
+          npx wrangler deploy \
             --var NEXTAUTH_URL:"$NEXTAUTH_URL" \
             --var NEXTAUTH_SECRET:"$NEXTAUTH_SECRET" \
             --var NEXT_PUBLIC_API_URL:"$NEXT_PUBLIC_API_URL" \
@@ -93,6 +93,7 @@ jobs:
             --var BASIC_AUTH_USER:"$BASIC_AUTH_USER" \
             --var BASIC_AUTH_PASSWORD:"$BASIC_AUTH_PASSWORD"
         env:
+          CLOUDFLARE_ENV: ${{ env.ENV }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 


### PR DESCRIPTION
## 概要
- Wranglerデプロイ時の環境指定方法を`--env`フラグから`CLOUDFLARE_ENV`環境変数に変更
- OpenNextが`wrangler deploy`をラップする際に`--env`フラグが失われる問題を修正
- 2025年11月に追加された公式の`CLOUDFLARE_ENV`環境変数を使用

## テスト計画
- [ ] Preview環境へのデプロイが成功することを確認
- [ ] デプロイログから警告メッセージが消えていることを確認
- [ ] Production環境（main）へのデプロイが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)