### PR TITLE
fix(api): Fix Google Form submission failing on Cloudflare Workers

### DIFF
--- a/apps/backend/src/routes/contact/handlers/submit-contact/submit-contact.ts
+++ b/apps/backend/src/routes/contact/handlers/submit-contact/submit-contact.ts
@@ -43,7 +43,7 @@ const GOOGLE_FORM_ENTRY_IDS = {
  * 2. URLSearchParamsに変換してGoogle Formsに送信
  *    - サーバーサイドからのfetchのためCORS制約なし
  *    - Google Formsは送信成功時に302リダイレクトを返す
- *    - リダイレクトを自動追従し、最終的な200レスポンスで成功を判定する
+ *    - リダイレクトを自動追従し、リダイレクト経由の200レスポンスで成功を判定する
  * 3. レスポンスステータスで成功/失敗を判定（200が成功）
  */
 export const submitContact: Handler = async (c) => {
@@ -78,7 +78,7 @@ export const submitContact: Handler = async (c) => {
 
 		// 3. レスポンスステータスで成功/失敗を判定
 		// Google Formsは302リダイレクト後、200のHTMLページを返す
-		if (response.ok) {
+		if (response.ok && response.redirected) {
 			return c.json({ success: true }, 200);
 		}
 


### PR DESCRIPTION
## 概要
- Cloudflare Workers で `redirect: "manual"` を使用すると、Google Forms の302リダイレクトが opaque redirect（ステータス0）として返され、送信成功の判定に失敗していた
- `redirect: "manual"` を削除してリダイレクトを自動追従させ、最終的な200レスポンスで `response.ok` により成功を判定するように修正

## テスト計画
- [ ] お問い合わせフォームから送信して成功レスポンスが返ることを確認
- [ ] Google スプレッドシートにデータが記録されていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)