### PR TITLE
fix(api): Diagnose Google Form 400 error on CI deploy

### DIFF
--- a/apps/backend/src/routes/contact/handlers/submit-contact/submit-contact.ts
+++ b/apps/backend/src/routes/contact/handlers/submit-contact/submit-contact.ts
@@ -85,6 +85,10 @@ export const submitContact: Handler = async (c) => {
 		console.error("Google Forms submission failed:", {
 			status: response.status,
 			statusText: response.statusText,
+			redirected: response.redirected,
+			urlPrefix: googleFormUrl.substring(0, 40),
+			urlSuffix: googleFormUrl.slice(-20),
+			urlLength: googleFormUrl.length,
 		});
 
 		return c.json(


### PR DESCRIPTION
## 概要
- CI（GitHub Actions）経由のデプロイでGoogle Form送信が400 Bad Requestエラーになる問題の診断
- ローカルからの`wrangler deploy`では正常に動作するため、環境変数の受け渡しに問題がある可能性が高い
- エラーログにURL情報（先頭・末尾・長さ）と`response.redirected`の値を追加し、原因を特定する

## 変更内容
- `submit-contact.ts`のエラーログに`urlPrefix`/`urlSuffix`/`urlLength`/`redirected`を追加
- セキュリティのためURL全体はログに出さず、先頭40文字と末尾20文字のみ出力

## テスト計画
- [x] `pnpm type-check` でエラーがないことを確認
- [x] `pnpm check` でlintエラーがないことを確認
- [ ] CIでデプロイ後、お問い合わせフォームからテスト送信
- [ ] Cloudflare Dashboardのログで`urlPrefix`/`urlSuffix`/`urlLength`を確認
- [ ] ログ結果に応じてPhase 2の対応を決定

🤖 Generated with [Claude Code](https://claude.ai/code)