### PR TITLE
fix(api): Use redirect manual mode for Google Form submission

### DIFF
--- a/apps/backend/src/routes/contact/handlers/submit-contact/submit-contact.ts
+++ b/apps/backend/src/routes/contact/handlers/submit-contact/submit-contact.ts
@@ -68,17 +68,22 @@ export const submitContact: Handler = async (c) => {
 
 		const googleFormUrl = c.env.GOOGLE_FORM_URL;
 
+		// リダイレクトを手動で制御し、302を成功として扱う
+		// Google Formsは送信成功時に302リダイレクトを返す
+		// CF Workersがリダイレクト先を follow すると予期しないステータスが返る場合がある
 		const response = await fetch(googleFormUrl, {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/x-www-form-urlencoded",
 			},
 			body: formData.toString(),
+			redirect: "manual",
 		});
 
 		// 3. レスポンスステータスで成功/失敗を判定
-		// Google Formsは302リダイレクト後、200のHTMLページを返す
-		if (response.ok && response.redirected) {
+		// Google Formsは送信成功時に302リダイレクトを返す
+		const isRedirect = response.status >= 300 && response.status < 400;
+		if (response.ok || isRedirect) {
 			return c.json({ success: true }, 200);
 		}
 


### PR DESCRIPTION
## 概要
- CI経由デプロイでGoogle Form送信が400 Bad Requestになる問題の修正
- 診断ログの結果、URLは正しく渡されていることを確認済み
- CF Workersがリダイレクトを follow した先で予期しないステータスが返る可能性があるため、`redirect: "manual"` で302自体を成功として判定するように変更
- エラーログにURL情報（先頭・末尾・長さ）と`response.redirected`を追加し、今後の診断を容易に

## テスト計画
- [x] `pnpm type-check` でエラーがないことを確認
- [x] `pnpm check` でlintエラーがないことを確認
- [ ] CIでデプロイ後、お問い合わせフォームから送信テスト
- [ ] Cloudflare Dashboardのログで成功を確認

🤖 Generated with [Claude Code](https://claude.ai/code)