### PR TITLE
fix(ci): Remove GOOGLE_FORM_URL from CI deploy vars to use Cloudflare secret

### DIFF
--- a/.github/workflows/_create-backend-env-file.yml
+++ b/.github/workflows/_create-backend-env-file.yml
@@ -19,8 +19,6 @@ on:
         required: true
       GEMINI_API_KEY:
         required: false # オプショナル（翻訳機能を使わない場合もある）
-      GOOGLE_FORM_URL:
-        required: true
 
 env:
   ENV: ${{ inputs.ENV }}
@@ -37,7 +35,6 @@ jobs:
           CORS_ORIGIN: ${{ secrets.CORS_ORIGIN }}
           ADMIN_EMAILS: ${{ secrets.ADMIN_EMAILS }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GOOGLE_FORM_URL: ${{ secrets.GOOGLE_FORM_URL }}
         run: |
           ENV_FILE=".env"
           echo "Creating Backend $ENV_FILE for ${{ env.ENV }} environment..."
@@ -46,7 +43,6 @@ jobs:
           echo "TURSO_AUTH_TOKEN=$TURSO_AUTH_TOKEN" >> $ENV_FILE
           echo "CORS_ORIGIN=$CORS_ORIGIN" >> $ENV_FILE
           echo "ADMIN_EMAILS=$ADMIN_EMAILS" >> $ENV_FILE
-          echo "GOOGLE_FORM_URL=$GOOGLE_FORM_URL" >> $ENV_FILE
 
           # GEMINI_API_KEYが設定されている場合のみ追加
           if [ ! -z "$GEMINI_API_KEY" ]; then

--- a/.github/workflows/_deploy-backend.yml
+++ b/.github/workflows/_deploy-backend.yml
@@ -79,16 +79,14 @@ jobs:
               --var TURSO_AUTH_TOKEN:"$TURSO_AUTH_TOKEN" \
               --var CORS_ORIGIN:"$CORS_ORIGIN" \
               --var ADMIN_EMAILS:"$ADMIN_EMAILS" \
-              --var GEMINI_API_KEY:"$GEMINI_API_KEY" \
-              --var GOOGLE_FORM_URL:"$GOOGLE_FORM_URL"
+              --var GEMINI_API_KEY:"$GEMINI_API_KEY"
           else
             # GEMINI_API_KEYが設定されていない場合
             npx wrangler deploy --env ${{ env.ENV }} \
               --var TURSO_DATABASE_URL:"$TURSO_DATABASE_URL" \
               --var TURSO_AUTH_TOKEN:"$TURSO_AUTH_TOKEN" \
               --var CORS_ORIGIN:"$CORS_ORIGIN" \
-              --var ADMIN_EMAILS:"$ADMIN_EMAILS" \
-              --var GOOGLE_FORM_URL:"$GOOGLE_FORM_URL"
+              --var ADMIN_EMAILS:"$ADMIN_EMAILS"
           fi
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -59,7 +59,6 @@ jobs:
       CORS_ORIGIN: ${{ needs.set-environment.outputs.environment == 'production' && secrets.CORS_ORIGIN_PROD || secrets.CORS_ORIGIN_PREVIEW }}
       ADMIN_EMAILS: ${{ secrets.ADMIN_EMAILS }}
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }} # 共通のAPIキーを使用
-      GOOGLE_FORM_URL: ${{ secrets.GOOGLE_FORM_URL }}
 
   # バックエンドをデプロイ
   backend-deploy:

--- a/apps/backend/src/routes/contact/handlers/submit-contact/submit-contact.ts
+++ b/apps/backend/src/routes/contact/handlers/submit-contact/submit-contact.ts
@@ -66,7 +66,8 @@ export const submitContact: Handler = async (c) => {
 		);
 		formData.append(GOOGLE_FORM_ENTRY_IDS.message, body.message);
 
-		const googleFormUrl = c.env.GOOGLE_FORM_URL;
+		// 末尾の空白やCR/LFを除去（環境変数に余分な文字が混入する場合の安全策）
+		const googleFormUrl = c.env.GOOGLE_FORM_URL.trim();
 
 		// リダイレクトを手動で制御し、302を成功として扱う
 		// Google Formsは送信成功時に302リダイレクトを返す


### PR DESCRIPTION
## 概要
- CIデプロイ時にGoogle Form送信が400 Bad Requestになる問題を修正
- CIの`--var`（plaintext variable binding）とCloudflareダッシュボードで設定済みのsecret（encrypted binding）が同名`GOOGLE_FORM_URL`で競合していたことが原因
- CIワークフローから`GOOGLE_FORM_URL`の受け渡しを削除し、Cloudflare secretに一本化
- 安全策として`GOOGLE_FORM_URL`に`.trim()`を追加（環境変数に余分な空白やCR/LFが混入する場合への対策）

## 変更内容
- `.github/workflows/_deploy-backend.yml`: `wrangler deploy`から`--var GOOGLE_FORM_URL`を削除
- `.github/workflows/_create-backend-env-file.yml`: `GOOGLE_FORM_URL`のsecret定義・env設定・`.env`書き込みを削除
- `.github/workflows/deploy-backend.yml`: `GOOGLE_FORM_URL`のsecrets受け渡しを削除
- `submit-contact.ts`: `c.env.GOOGLE_FORM_URL.trim()`を追加

## テスト計画
- [ ] CIがpreview環境にデプロイされることを確認
- [ ] preview環境のAPIでお問い合わせ送信をテストし、成功（302リダイレクト）を確認
- [ ] Cloudflare Workersのログでエラーがないことを確認

## 注意事項
- `GOOGLE_FORM_URL`の更新は今後Cloudflareダッシュボードまたは`wrangler secret put`で行う

🤖 Generated with [Claude Code](https://claude.ai/code)