### PR TITLE
fix(api): Remove diagnostic debug logs from Google Form submission

### DIFF
--- a/apps/backend/src/routes/contact/handlers/submit-contact/submit-contact.ts
+++ b/apps/backend/src/routes/contact/handlers/submit-contact/submit-contact.ts
@@ -88,17 +88,9 @@ export const submitContact: Handler = async (c) => {
 			return c.json({ success: true }, 200);
 		}
 
-		const responseBody = await response.text();
 		console.error("Google Forms submission failed:", {
 			status: response.status,
 			statusText: response.statusText,
-			redirected: response.redirected,
-			urlPrefix: googleFormUrl.substring(0, 40),
-			urlSuffix: googleFormUrl.slice(-20),
-			urlLength: googleFormUrl.length,
-			formDataKeys: Array.from(formData.keys()),
-			formDataBody: formData.toString().substring(0, 200),
-			responseBodyPrefix: responseBody.substring(0, 500),
 		});
 
 		return c.json(


### PR DESCRIPTION
## 概要
- Google Form送信時のデバッグ用詳細ログ（URL情報、フォームデータ、レスポンスボディ等）を削除
- エラーログを `status` と `statusText` のみのシンプルな形に戻した
- GOOGLE_FORM_URLはCloudflareダッシュボードでシークレットとして設定済み

## テスト計画
- [ ] CIデプロイが成功すること
- [ ] お問い合わせフォームから送信テストを行い、正常に送信できること

🤖 Generated with [Claude Code](https://claude.ai/code)