### PR TITLE
chore(ci): Add cooldown setting to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
   # 例: react, next.js, typescript など
   - package-ecosystem: "npm"
     directory: "/"
+    cooldown:
+      default-days: 14 # リリースから14日以内のパッケージはPRを作成しない
     schedule:
       interval: "daily" # 毎日実行
       time: "08:00" # 午前8時（JST）

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     cooldown:
-      default-days: 14 # リリースから14日以内のパッケージはPRを作成しない
+      default-days: 14 # pnpm-workspace.yamlのminimumReleaseAgeと同じ値にすること
     schedule:
       interval: "daily" # 毎日実行
       time: "08:00" # 午前8時（JST）

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,4 +2,5 @@ packages:
   - 'apps/*'
   - 'packages/*'
 
+# dependabot.ymlのcooldown.default-daysと同じ値にすること
 minimumReleaseAge: 14d


### PR DESCRIPTION
## 概要
- dependabot.ymlに `cooldown: default-days: 14` を追加
- リリースから14日以内のパッケージに対してdependabotがPRを作成しないようにする
- pnpmの `minimumReleaseAge: 14d` と同じポリシーをdependabot側でも適用
- パッケージごとの例外設定（`minimumReleaseAgeExclude`）を不要にする

## テスト計画
- [x] `pnpm type-check` がパスすること
- [x] `pnpm check` がパスすること

🤖 Generated with [Claude Code](https://claude.ai/code)