### PR TITLE
feat(home): Add profile photo and refine hero CTAs on top page

### DIFF
--- a/apps/frontend/src/views/home/ui/home-view.tsx
+++ b/apps/frontend/src/views/home/ui/home-view.tsx
@@ -1,11 +1,23 @@
 "use client";
 
-import { ArrowRight } from "lucide-react";
+import { ArrowRight, User } from "lucide-react";
+import Image from "next/image";
 import { useTranslations } from "next-intl";
 
 import { Link } from "@/shared/lib";
 import { BlogNotice, PageContainer } from "@/shared/ui";
 import { ArticlesList, PopularArticlesList } from "@/widgets";
+
+/**
+ * ヒーローに表示するプロフィール写真のパス。
+ *
+ * @description
+ * まだ写真ファイルが用意できていないため、暫定で `null` を指定している。
+ * 写真を用意したら `apps/frontend/public/images/` に画像（例: profile.webp）を
+ * 置き、ここを `"/images/profile.webp"` のように差し替えるだけで表示される。
+ * `null` の間はプロフィールアイコンのプレースホルダーが表示される。
+ */
+const PROFILE_IMAGE_SRC: string | null = null;
 
 /**
  * ホームページのメインビューコンポーネント
@@ -32,40 +44,73 @@ export function HomeView() {
 				区切る（罫線は引かない）。人気記事と最新記事は同じ「記事」
 				ブロックにまとめ、内部だけ space-y で分ける。
 			*/}
-			{/* ブロック1: 自己紹介ヒーロー */}
-			<section className="space-y-5">
-				{/* 大見出し: サイズに応じて字間を詰める（Appleの光学的なトラッキング） */}
-				<h1 className="text-3xl sm:text-4xl font-bold leading-tight tracking-[-0.02em]">
-					{t("hero.title")}
-				</h1>
-				<p className="text-base leading-relaxed text-foreground">
-					{t("hero.description")}
-				</p>
-				{/* Aboutページへの導線（お問い合わせと同じ塗りボタン） */}
-				<div className="flex flex-wrap items-center gap-x-4 gap-y-3">
-					<span className="text-sm text-muted-foreground">
-						{t("hero.aboutPrompt")}
-					</span>
-					<Link
-						href="/about"
-						className="group inline-flex items-center gap-1.5 rounded-full bg-foreground px-5 py-2.5 text-sm font-semibold text-background shadow-sm transition-all duration-300 ease-out hover:-translate-y-0.5 hover:shadow-lg active:translate-y-0 active:scale-95 motion-reduce:transition-none motion-reduce:hover:translate-y-0 motion-reduce:active:scale-100"
-					>
-						{t("hero.aboutLink")}
-						<ArrowRight className="h-4 w-4 transition-transform duration-300 ease-out group-hover:translate-x-0.5 motion-reduce:transition-none motion-reduce:group-hover:translate-x-0" />
-					</Link>
+			{/*
+				ブロック1: 自己紹介ヒーロー
+				左にテキスト・右にプロフィール写真の2カラム。モバイル（縦）では
+				flex-col-reverse により写真を上・テキストを下に積む。デスクトップ
+				（md以上）では flex-row で「左テキスト / 右写真」に切り替える。
+			*/}
+			<section className="flex flex-col-reverse gap-8 md:flex-row md:items-center md:justify-between md:gap-12">
+				{/* テキスト側（見出し・自己紹介・各導線） */}
+				<div className="space-y-5 md:flex-1">
+					{/* 大見出し: サイズに応じて字間を詰める（Appleの光学的なトラッキング） */}
+					<h1 className="text-3xl sm:text-4xl font-bold leading-tight tracking-[-0.02em]">
+						{t("hero.title")}
+					</h1>
+					<p className="text-base leading-relaxed text-foreground">
+						{t("hero.description")}
+					</p>
+					{/* Aboutページへの導線（お問い合わせと同じ塗りボタン） */}
+					<div className="flex flex-wrap items-center gap-x-4 gap-y-3">
+						<span className="text-sm text-muted-foreground">
+							{t("hero.aboutPrompt")}
+						</span>
+						<Link
+							href="/about"
+							className="group inline-flex items-center gap-1.5 rounded-full bg-foreground px-5 py-2.5 text-sm font-semibold text-background shadow-sm transition-all duration-300 ease-out hover:-translate-y-0.5 hover:shadow-lg active:translate-y-0 active:scale-95 motion-reduce:transition-none motion-reduce:hover:translate-y-0 motion-reduce:active:scale-100"
+						>
+							{t("hero.aboutLink")}
+							<ArrowRight className="h-4 w-4 transition-transform duration-300 ease-out group-hover:translate-x-0.5 motion-reduce:transition-none motion-reduce:group-hover:translate-x-0" />
+						</Link>
+					</div>
+					{/* お仕事相談への導線（Contactページへ誘導） */}
+					<div className="flex flex-wrap items-center gap-x-4 gap-y-3">
+						<span className="text-sm text-muted-foreground">
+							{t("hero.contactPrompt")}
+						</span>
+						<Link
+							href="/contact"
+							className="group inline-flex items-center gap-1.5 rounded-full bg-foreground px-5 py-2.5 text-sm font-semibold text-background shadow-sm transition-all duration-300 ease-out hover:-translate-y-0.5 hover:shadow-lg active:translate-y-0 active:scale-95 motion-reduce:transition-none motion-reduce:hover:translate-y-0 motion-reduce:active:scale-100"
+						>
+							{t("hero.contactLink")}
+							<ArrowRight className="h-4 w-4 transition-transform duration-300 ease-out group-hover:translate-x-0.5 motion-reduce:transition-none motion-reduce:group-hover:translate-x-0" />
+						</Link>
+					</div>
 				</div>
-				{/* お仕事相談への導線（Contactページへ誘導） */}
-				<div className="flex flex-wrap items-center gap-x-4 gap-y-3">
-					<span className="text-sm text-muted-foreground">
-						{t("hero.contactPrompt")}
-					</span>
-					<Link
-						href="/contact"
-						className="group inline-flex items-center gap-1.5 rounded-full bg-foreground px-5 py-2.5 text-sm font-semibold text-background shadow-sm transition-all duration-300 ease-out hover:-translate-y-0.5 hover:shadow-lg active:translate-y-0 active:scale-95 motion-reduce:transition-none motion-reduce:hover:translate-y-0 motion-reduce:active:scale-100"
-					>
-						{t("hero.contactLink")}
-						<ArrowRight className="h-4 w-4 transition-transform duration-300 ease-out group-hover:translate-x-0.5 motion-reduce:transition-none motion-reduce:group-hover:translate-x-0" />
-					</Link>
+
+				{/*
+					写真側（円形）。写真が未設定（PROFILE_IMAGE_SRC が null）の間は
+					プロフィールアイコンのプレースホルダーを表示し、レイアウト崩れや
+					画像の404を防ぐ。写真を差し替えれば同じ円形枠に収まる。
+				*/}
+				<div className="mx-auto shrink-0 md:mx-0">
+					{PROFILE_IMAGE_SRC ? (
+						<Image
+							src={PROFILE_IMAGE_SRC}
+							alt={t("hero.photoAlt")}
+							width={192}
+							height={192}
+							priority
+							className="size-32 rounded-full object-cover ring-1 ring-border sm:size-44 md:size-32"
+						/>
+					) : (
+						<div
+							aria-hidden="true"
+							className="flex size-32 items-center justify-center rounded-full bg-muted ring-1 ring-border sm:size-44 md:size-32"
+						>
+							<User className="size-12 text-muted-foreground" />
+						</div>
+					)}
 				</div>
 			</section>
 

--- a/apps/frontend/src/views/home/ui/home-view.tsx
+++ b/apps/frontend/src/views/home/ui/home-view.tsx
@@ -12,12 +12,13 @@ import { ArticlesList, PopularArticlesList } from "@/widgets";
  * ヒーローに表示するプロフィール写真のパス。
  *
  * @description
- * まだ写真ファイルが用意できていないため、暫定で `null` を指定している。
- * 写真を用意したら `apps/frontend/public/images/` に画像（例: profile.webp）を
- * 置き、ここを `"/images/profile.webp"` のように差し替えるだけで表示される。
- * `null` の間はプロフィールアイコンのプレースホルダーが表示される。
+ * GitHubアバターをそのまま利用している。`next.config.js` で
+ * `images.unoptimized: true` を指定しているため、外部URLでも
+ * `remotePatterns` の許可設定なしで表示できる。
+ * `null` にするとプロフィールアイコンのプレースホルダーが表示される。
  */
-const PROFILE_IMAGE_SRC: string | null = null;
+const PROFILE_IMAGE_SRC: string | null =
+	"https://avatars.githubusercontent.com/u/16120550?s=400&v=4";
 
 /**
  * ホームページのメインビューコンポーネント

--- a/apps/frontend/src/views/home/ui/home-view.tsx
+++ b/apps/frontend/src/views/home/ui/home-view.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 import { useTranslations } from "next-intl";
 
 import { Link } from "@/shared/lib";
-import { BlogNotice, PageContainer } from "@/shared/ui";
+import { BlogNotice, Button, PageContainer } from "@/shared/ui";
 import { ArticlesList, PopularArticlesList } from "@/widgets";
 
 /**
@@ -60,31 +60,29 @@ export function HomeView() {
 					<p className="text-base leading-relaxed text-foreground">
 						{t("hero.description")}
 					</p>
-					{/* Aboutページへの導線（お問い合わせと同じ塗りボタン） */}
-					<div className="flex flex-wrap items-center gap-x-4 gap-y-3">
+					{/* Aboutページへの導線（お問い合わせと同じリンクスタイル） */}
+					<div className="flex flex-wrap items-center gap-x-2 gap-y-2">
 						<span className="text-sm text-muted-foreground">
 							{t("hero.aboutPrompt")}
 						</span>
-						<Link
-							href="/about"
-							className="group inline-flex items-center gap-1.5 rounded-full bg-foreground px-5 py-2.5 text-sm font-semibold text-background shadow-sm transition-all duration-300 ease-out hover:-translate-y-0.5 hover:shadow-lg active:translate-y-0 active:scale-95 motion-reduce:transition-none motion-reduce:hover:translate-y-0 motion-reduce:active:scale-100"
-						>
-							{t("hero.aboutLink")}
-							<ArrowRight className="h-4 w-4 transition-transform duration-300 ease-out group-hover:translate-x-0.5 motion-reduce:transition-none motion-reduce:group-hover:translate-x-0" />
-						</Link>
+						<Button asChild variant="link" className="h-auto p-0">
+							<Link href="/about">
+								{t("hero.aboutLink")}
+								<ArrowRight className="h-4 w-4" />
+							</Link>
+						</Button>
 					</div>
 					{/* お仕事相談への導線（Contactページへ誘導） */}
-					<div className="flex flex-wrap items-center gap-x-4 gap-y-3">
+					<div className="flex flex-wrap items-center gap-x-2 gap-y-2">
 						<span className="text-sm text-muted-foreground">
 							{t("hero.contactPrompt")}
 						</span>
-						<Link
-							href="/contact"
-							className="group inline-flex items-center gap-1.5 rounded-full bg-foreground px-5 py-2.5 text-sm font-semibold text-background shadow-sm transition-all duration-300 ease-out hover:-translate-y-0.5 hover:shadow-lg active:translate-y-0 active:scale-95 motion-reduce:transition-none motion-reduce:hover:translate-y-0 motion-reduce:active:scale-100"
-						>
-							{t("hero.contactLink")}
-							<ArrowRight className="h-4 w-4 transition-transform duration-300 ease-out group-hover:translate-x-0.5 motion-reduce:transition-none motion-reduce:group-hover:translate-x-0" />
-						</Link>
+						<Button asChild variant="link" className="h-auto p-0">
+							<Link href="/contact">
+								{t("hero.contactLink")}
+								<ArrowRight className="h-4 w-4" />
+							</Link>
+						</Button>
 					</div>
 				</div>
 

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -30,7 +30,8 @@
 			"aboutPrompt": "For a fuller profile and background,",
 			"aboutLink": "visit About",
 			"contactPrompt": "Open to work inquiries — feel free to reach out",
-			"contactLink": "Contact"
+			"contactLink": "Contact",
+			"photoAlt": "Profile photo of saneatsu"
 		},
 		"popularArticles": {
 			"title": "Popular Articles"

--- a/packages/i18n/src/locales/ja.json
+++ b/packages/i18n/src/locales/ja.json
@@ -30,7 +30,8 @@
 			"aboutPrompt": "プロフィールや経歴の詳細は",
 			"aboutLink": "Aboutページへ",
 			"contactPrompt": "お仕事のご相談も承っています。お気軽にどうぞ",
-			"contactLink": "お問い合わせ"
+			"contactLink": "お問い合わせ",
+			"photoAlt": "saneatsuのプロフィール写真"
 		},
 		"popularArticles": {
 			"title": "人気記事"


### PR DESCRIPTION
## 概要
- トップページのヒーローを「左テキスト / 右プロフィール写真」の2カラムに変更（モバイルは写真上・テキスト下に積む）
- プロフィール写真に GitHub アバターを設定（`images.unoptimized: true` のため `remotePatterns` 追加は不要）
- About・お問い合わせの導線を独自スタイルの生Linkから shadcn Button（`variant="link"`）に統一し、about-view とハウススタイルを揃えた
- 画像の alt 用に `home.hero.photoAlt` を ja/en へ追加

## テスト計画
- [x] `pnpm type-check` 通過
- [x] `npx biome check` 通過
- [ ] トップページのヒーローがPC/モバイル両方で崩れず表示されること
- [ ] アバター画像が円形で表示されること
- [ ] About・お問い合わせリンクが正しく遷移すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)