### PR TITLE
fix(dashboard): Count this month's new articles instead of hardcoded 0

### DIFF
--- a/apps/backend/src/lib/get-this-month-range.test.ts
+++ b/apps/backend/src/lib/get-this-month-range.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { getThisMonthRangeJst } from "./get-this-month-range";
+
+describe("getThisMonthRangeJst", () => {
+	describe("Unit Test", () => {
+		it("月央の日時から、JSTの月初〜翌月初（排他上限）をUTC ISO文字列で返す", () => {
+			// Given: JST 2025-11-15 09:00 に相当するUTC日時
+			const now = new Date("2025-11-15T00:00:00.000Z");
+
+			// When
+			const range = getThisMonthRangeJst(now);
+
+			// Then: JST 11月の範囲。月初はUTCでは10/31 15:00
+			expect(range).toEqual({
+				start: "2025-10-31T15:00:00.000Z",
+				end: "2025-11-30T15:00:00.000Z",
+			});
+		});
+
+		it("UTCではまだ前月末だが、JSTでは翌月に入っている境界を正しく翌月として扱う", () => {
+			// Given: UTCは10/31だが、JSTでは既に11/01 00:30
+			const now = new Date("2025-10-31T15:30:00.000Z");
+
+			// When
+			const range = getThisMonthRangeJst(now);
+
+			// Then: JSTの月＝11月として集計される
+			expect(range).toEqual({
+				start: "2025-10-31T15:00:00.000Z",
+				end: "2025-11-30T15:00:00.000Z",
+			});
+		});
+
+		it("JST月初の1秒前は前月として扱う（境界値-1）", () => {
+			// Given: JST 2025-10-31 23:59:59
+			const now = new Date("2025-10-31T14:59:59.000Z");
+
+			// When
+			const range = getThisMonthRangeJst(now);
+
+			// Then: JSTの月＝10月
+			expect(range).toEqual({
+				start: "2025-09-30T15:00:00.000Z",
+				end: "2025-10-31T15:00:00.000Z",
+			});
+		});
+
+		it("JST月初ちょうどは当月として扱う（境界値0）", () => {
+			// Given: JST 2025-11-01 00:00:00
+			const now = new Date("2025-10-31T15:00:00.000Z");
+
+			// When
+			const range = getThisMonthRangeJst(now);
+
+			// Then: JSTの月＝11月
+			expect(range).toEqual({
+				start: "2025-10-31T15:00:00.000Z",
+				end: "2025-11-30T15:00:00.000Z",
+			});
+		});
+
+		it("年を跨ぐ場合（JST 12月→翌年1月）も正しく計算する", () => {
+			// Given: UTCは2025/12/31だが、JSTでは2026/01/01 05:00
+			const now = new Date("2025-12-31T20:00:00.000Z");
+
+			// When
+			const range = getThisMonthRangeJst(now);
+
+			// Then: JSTの月＝2026年1月
+			expect(range).toEqual({
+				start: "2025-12-31T15:00:00.000Z",
+				end: "2026-01-31T15:00:00.000Z",
+			});
+		});
+
+		it("12月は翌月の上限が翌年1月になる", () => {
+			// Given: JST 2025-12-15 09:00
+			const now = new Date("2025-12-15T00:00:00.000Z");
+
+			// When
+			const range = getThisMonthRangeJst(now);
+
+			// Then: JSTの月＝12月、上限は翌年1/1(JST)＝12/31 15:00(UTC)
+			expect(range).toEqual({
+				start: "2025-11-30T15:00:00.000Z",
+				end: "2025-12-31T15:00:00.000Z",
+			});
+		});
+	});
+});

--- a/apps/backend/src/lib/get-this-month-range.ts
+++ b/apps/backend/src/lib/get-this-month-range.ts
@@ -1,0 +1,42 @@
+/** JST（Asia/Tokyo）のUTCからのオフセット（ミリ秒）。DSTが無いため固定値で扱える */
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+/**
+ * 「今月」の期間をJST基準で算出する。
+ *
+ * @description
+ * ダッシュボードの「今月の新規記事数」などをJST（日本時間）の月境界で集計するために使う。
+ * DBの `created_at` はアプリ側で `new Date().toISOString()`（UTCのISO 8601文字列）として
+ * 保存されるため、返す境界値も同じISO 8601文字列（UTC）で返し、そのまま文字列比較
+ * （gte / lt）に使えるようにしている。
+ *
+ * Cloudflare Workers のランタイムは常にUTCで動作するため、`now` のローカルタイムゾーンに
+ * 依存せず、明示的に+9時間してJSTの年月を求めている。
+ *
+ * 1. `now` に+9時間してJST上の日時を作り、その年・月を取得する
+ * 2. JSTの「当月1日 0時0分0秒」をUTCの瞬間に戻す（-9時間）
+ * 3. 同様にJSTの「翌月1日 0時0分0秒」を上限（排他）として算出する
+ *
+ * @param now - 基準となる現在時刻（UTCのDate）
+ * @returns 当月の開始（含む）と翌月の開始（含まない）をUTCのISO 8601文字列で返す
+ */
+export function getThisMonthRangeJst(now: Date): {
+	start: string;
+	end: string;
+} {
+	// 1. JST上での年・月を求める
+	const jstNow = new Date(now.getTime() + JST_OFFSET_MS);
+	const jstYear = jstNow.getUTCFullYear();
+	const jstMonth = jstNow.getUTCMonth();
+
+	// 2. JSTの当月1日0時をUTCの瞬間に変換
+	const start = new Date(Date.UTC(jstYear, jstMonth, 1) - JST_OFFSET_MS);
+
+	// 3. JSTの翌月1日0時をUTCの瞬間に変換（排他上限）。月が12を超える場合もDate.UTCが年を繰り上げる
+	const end = new Date(Date.UTC(jstYear, jstMonth + 1, 1) - JST_OFFSET_MS);
+
+	return {
+		start: start.toISOString(),
+		end: end.toISOString(),
+	};
+}

--- a/apps/backend/src/routes/dashboard/handlers/get-overview/get-overview.test.ts
+++ b/apps/backend/src/routes/dashboard/handlers/get-overview/get-overview.test.ts
@@ -88,6 +88,13 @@ describe("GET /dashboard/overview - ダッシュボード概要取得", () => {
 			}),
 		};
 
+		// 今月の新規記事数のモック（published + draft をJST月範囲で集計）
+		const thisMonthArticlesCountMock = {
+			from: vi.fn().mockReturnValue({
+				where: vi.fn().mockResolvedValue([{ count: 7 }]),
+			}),
+		};
+
 		// 総閲覧数のモック（articlesテーブルから取得、言語フィルターなし）
 		const totalViewsMock = {
 			from: vi.fn().mockResolvedValue([{ totalViews: 5000 }]),
@@ -196,6 +203,7 @@ describe("GET /dashboard/overview - ダッシュボード概要取得", () => {
 			.mockReturnValueOnce(publishedArticlesCountMock) // 公開済み記事数
 			.mockReturnValueOnce(draftArticlesCountMock) // 下書き記事数
 			.mockReturnValueOnce(archivedArticlesCountMock) // アーカイブ記事数
+			.mockReturnValueOnce(thisMonthArticlesCountMock) // 今月の新規記事数
 			.mockReturnValueOnce(totalViewsMock) // 総閲覧数
 			.mockReturnValueOnce(thisMonthViewsMock) // 今月の閲覧数
 			.mockReturnValueOnce(topArticlesMock) // 人気記事トップ5
@@ -228,6 +236,7 @@ describe("GET /dashboard/overview - ダッシュボード概要取得", () => {
 		expect(data.articleStats.publishedArticles).toBe(80);
 		expect(data.articleStats.draftArticles).toBe(15);
 		expect(data.articleStats.archivedArticles).toBe(5);
+		expect(data.articleStats.thisMonthArticles).toBe(7);
 		expect(data.articleStats.totalViews).toBe(5000);
 
 		// 人気記事が取得できていること
@@ -289,6 +298,13 @@ describe("GET /dashboard/overview - ダッシュボード概要取得", () => {
 			}),
 		};
 
+		// 今月の新規記事数のモック（published + draft をJST月範囲で集計）
+		const thisMonthArticlesCountMock = {
+			from: vi.fn().mockReturnValue({
+				where: vi.fn().mockResolvedValue([{ count: 12 }]),
+			}),
+		};
+
 		// 総閲覧数のモック（articlesテーブルから取得、言語フィルターなし）
 		const totalViewsMock = {
 			from: vi.fn().mockResolvedValue([{ totalViews: 10000 }]),
@@ -333,6 +349,7 @@ describe("GET /dashboard/overview - ダッシュボード概要取得", () => {
 			.mockReturnValueOnce(publishedArticlesCountMock) // 公開済み記事数
 			.mockReturnValueOnce(draftArticlesCountMock) // 下書き記事数
 			.mockReturnValueOnce(archivedArticlesCountMock) // アーカイブ記事数
+			.mockReturnValueOnce(thisMonthArticlesCountMock) // 今月の新規記事数
 			.mockReturnValueOnce(totalViewsMock) // 総閲覧数
 			.mockReturnValueOnce(thisMonthViewsMock) // 今月の閲覧数
 			.mockReturnValueOnce(topArticlesMock) // 人気記事トップ5
@@ -362,6 +379,7 @@ describe("GET /dashboard/overview - ダッシュボード概要取得", () => {
 		expect(data.articleStats.publishedArticles).toBe(150);
 		expect(data.articleStats.draftArticles).toBe(30);
 		expect(data.articleStats.archivedArticles).toBe(20);
+		expect(data.articleStats.thisMonthArticles).toBe(12);
 		expect(data.articleStats.totalViews).toBe(10000);
 		expect(data.contributions).toBeDefined();
 	});

--- a/apps/backend/src/routes/dashboard/handlers/get-overview/get-overview.ts
+++ b/apps/backend/src/routes/dashboard/handlers/get-overview/get-overview.ts
@@ -1,10 +1,11 @@
 import type { RouteHandler } from "@hono/zod-openapi";
 import type { DashboardOverviewResponse } from "@saneatsu/schemas";
-import { and, count, desc, eq, gte, inArray, sql } from "drizzle-orm";
+import { and, count, desc, eq, gte, inArray, lt, sql } from "drizzle-orm";
 
 import type { Env } from "@/env";
 import { getDatabase } from "@/lib/database";
 import { getContributionSummary } from "@/lib/get-contribution-summary";
+import { getThisMonthRangeJst } from "@/lib/get-this-month-range";
 
 import type { getDashboardOverviewRoute } from "./get-overview.openapi";
 
@@ -48,12 +49,17 @@ export const getDashboardOverview: Handler = async (c) => {
 		const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
 		const startOfMonthStr = startOfMonth.toISOString().split("T")[0];
 
+		// 今月の範囲（JST基準）。created_atはUTCのISO 8601文字列で保存されるため、
+		// JSTの月初〜翌月初もUTCのISO 8601文字列で受け取り、そのまま文字列比較に使う
+		const thisMonthRange = getThisMonthRangeJst(now);
+
 		// 3. 記事統計の取得（概要版）
 		const [
 			totalArticlesResult,
 			publishedArticlesResult,
 			draftArticlesResult,
 			archivedArticlesResult,
+			thisMonthArticlesResult,
 		] = await Promise.all([
 			db.select({ count: count() }).from(articles),
 			db
@@ -68,6 +74,17 @@ export const getDashboardOverview: Handler = async (c) => {
 				.select({ count: count() })
 				.from(articles)
 				.where(eq(articles.status, "archived")),
+			// 今月の新規作成記事数（published + draft、JSTの月範囲を排他上限付きで集計）
+			db
+				.select({ count: count() })
+				.from(articles)
+				.where(
+					and(
+						inArray(articles.status, ["published", "draft"]),
+						gte(articles.createdAt, thisMonthRange.start),
+						lt(articles.createdAt, thisMonthRange.end)
+					)
+				),
 		]);
 
 		// 4. 閲覧数統計
@@ -203,7 +220,7 @@ export const getDashboardOverview: Handler = async (c) => {
 				publishedArticles: publishedArticlesResult[0]?.count || 0,
 				draftArticles: draftArticlesResult[0]?.count || 0,
 				archivedArticles: archivedArticlesResult[0]?.count || 0,
-				thisMonthArticles: 0, // 概要版では省略
+				thisMonthArticles: thisMonthArticlesResult[0]?.count || 0,
 				totalViews: Number(totalViewsResult[0]?.totalViews) || 0,
 				thisMonthViews: Number(thisMonthViewsResult[0]?.thisMonthViews) || 0,
 			},


### PR DESCRIPTION
## 概要

- ダッシュボードの「今月の新規記事」カードが常に `0` を表示していたバグを修正したのだ。
- 原因は、フロントが参照する overview エンドポイント（`get-overview.ts`）が `thisMonthArticles: 0` とベタ書きで返していたことだった。実際に集計するロジックは別の `/dashboard/stats` にあったが、フロントからは呼ばれていなかった。
- overview ハンドラー内で実際に今月の新規記事数を集計するように変更した。

## 実装の詳細

- **JST基準の月範囲を計算する純粋関数を追加**（`apps/backend/src/lib/get-this-month-range.ts`）
  - `getThisMonthRangeJst(now)` が「今月の月初」〜「翌月の月初（排他上限）」をUTCのISO 8601文字列で返す。
  - Cloudflare Workers は常にUTCで動作するため、明示的に+9時間してJSTの年月を判定している。
  - `created_at` はアプリ側（`create-article.ts`）が `new Date().toISOString()` でISO 8601（UTC）保存しているため、境界値も同形式にして文字列比較（`gte` / `lt`）が正しく成立するようにしている。
- **集計条件**
  - ステータス: `published` + `draft`（`archived` は除外）
  - 期間: JSTの今月（下限を含み、上限は翌月初を排他）

## テスト計画

- [x] `get-this-month-range.test.ts` … 月央 / UTCとJSTで月が異なる境界 / 境界±1 / 年跨ぎ の6ケース（境界値網羅）
- [x] `get-overview.test.ts` … 既存2テストに `thisMonthArticles` の検証を追加
- [x] `pnpm type-check` 通過
- [x] `npx biome check` 通過
- [ ] レビュアー確認: ステータスは published + draft でよいか（archived除外の妥当性）
- [ ] レビュアー確認: 月境界がJSTで期待どおりか

## 残課題（本PRスコープ外）

- `get-stats.ts`（`/dashboard/stats`）に同種のバグ（上限なし・ステータス無視・ローカルTZ月初）が残っている。ただしフロントから未使用かつテストが無いため、別PRで「削除」または「テスト追加のうえ `getThisMonthRangeJst` へ寄せる」対応を推奨する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)