### PR TITLE
feat(i18n)!: Default to en and add Spanish (es) support

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -32,3 +32,8 @@ jobs:
 
       - name: Report Coverage
         uses: davelosert/vitest-coverage-report-action@v2
+
+      # ミドルウェアテストはメインのVitestから除外されているため個別に実行する。
+      # (別環境・別setupが必要。理由の詳細は vitest.config.middleware.mts を参照)
+      - name: Run middleware tests
+        run: pnpm --filter @saneatsu/frontend test:middleware

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -14,7 +14,7 @@
 	"scripts": {
 		"build": "tsc",
 		"dev": "tsx watch src/dev.ts",
-		"db:backfill-es": "tsx src/scripts/backfill-es-translations.ts",
+		"db:backfill": "tsx src/scripts/backfill-translations.ts",
 		"dev:worker": "wrangler dev",
 		"start": "node dist/index.js",
 		"deploy": "wrangler deploy",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -14,6 +14,7 @@
 	"scripts": {
 		"build": "tsc",
 		"dev": "tsx watch src/dev.ts",
+		"db:backfill-es": "tsx src/scripts/backfill-es-translations.ts",
 		"dev:worker": "wrangler dev",
 		"start": "node dist/index.js",
 		"deploy": "wrangler deploy",

--- a/apps/backend/src/lib/translate/translate-with-gemini.ts
+++ b/apps/backend/src/lib/translate/translate-with-gemini.ts
@@ -1,18 +1,17 @@
 import { GoogleGenerativeAI } from "@google/generative-ai";
 
-/**
- * 翻訳先の言語コード
- *
- * @description
- * 翻訳元は常に日本語（ja）なので、翻訳先の言語のみを型で表現する。
- */
-export type TargetLanguage = "en" | "es";
+import type { TargetLanguage } from "../../services/gemini-translation/gemini-translation";
+
+// 翻訳先の言語コードは gemini-translation.ts（TARGET_LANGUAGES）を単一ソースとし、
+// ここでは型のみを再エクスポートして後方互換を保つ。
+export type { TargetLanguage };
 
 /**
  * 翻訳先言語ごとの Gemini システムプロンプト
  *
  * @description
  * 言語名を英語で明示することで、Gemini が自然な対象言語に翻訳できるようにする。
+ * TARGET_LANGUAGES に言語を足すと、この Record が不足しビルドエラーになる。
  */
 const SYSTEM_INSTRUCTION_BY_LANGUAGE: Record<TargetLanguage, string> = {
 	en: "You are a professional translator. Translate the given Japanese text to natural English. Return only the translated text without any explanations or additional commentary.",

--- a/apps/backend/src/lib/translate/translate-with-gemini.ts
+++ b/apps/backend/src/lib/translate/translate-with-gemini.ts
@@ -1,21 +1,41 @@
 import { GoogleGenerativeAI } from "@google/generative-ai";
 
 /**
- * Geminiで日本語から英語に翻訳
+ * 翻訳先の言語コード
  *
  * @description
- * Google Gemini APIを使用して日本語テキストを英語に翻訳する。
+ * 翻訳元は常に日本語（ja）なので、翻訳先の言語のみを型で表現する。
+ */
+export type TargetLanguage = "en" | "es";
+
+/**
+ * 翻訳先言語ごとの Gemini システムプロンプト
+ *
+ * @description
+ * 言語名を英語で明示することで、Gemini が自然な対象言語に翻訳できるようにする。
+ */
+const SYSTEM_INSTRUCTION_BY_LANGUAGE: Record<TargetLanguage, string> = {
+	en: "You are a professional translator. Translate the given Japanese text to natural English. Return only the translated text without any explanations or additional commentary.",
+	es: "You are a professional translator. Translate the given Japanese text to natural Spanish (español). Return only the translated text without any explanations or additional commentary.",
+};
+
+/**
+ * Geminiで日本語から指定言語に翻訳
+ *
+ * @description
+ * Google Gemini APIを使用して日本語テキストを指定した言語に翻訳する。
  *
  * 処理フロー:
  * 1. GoogleGenerativeAIクライアントを初期化
- * 2. gemini-1.5-flashモデルを使用
- * 3. システムプロンプトで翻訳タスクを定義
+ * 2. gemini-2.5-flashモデルを使用
+ * 3. 翻訳先言語に応じたシステムプロンプトで翻訳タスクを定義
  * 4. テキストを翻訳
  * 5. 翻訳結果を返す
  *
  * @param text - 翻訳する日本語テキスト
  * @param apiKey - Gemini API Key
- * @returns 英語に翻訳されたテキスト
+ * @param targetLanguage - 翻訳先の言語コード（省略時は英語）
+ * @returns 指定言語に翻訳されたテキスト
  *
  * @throws APIエラーまたはレスポンスが空の場合にエラーを投げる
  *
@@ -23,14 +43,16 @@ import { GoogleGenerativeAI } from "@google/generative-ai";
  * ```typescript
  * const translated = await translateWithGemini(
  *   "東京タワーの夕景",
- *   env.GEMINI_API_KEY
+ *   env.GEMINI_API_KEY,
+ *   "es"
  * );
- * // => "Tokyo Tower at Sunset"
+ * // => "Torre de Tokio al atardecer"
  * ```
  */
 export async function translateWithGemini(
 	text: string,
-	apiKey: string
+	apiKey: string,
+	targetLanguage: TargetLanguage = "en"
 ): Promise<string> {
 	// 空文字列の場合は翻訳せずに返す
 	if (!text || text.trim().length === 0) {
@@ -43,8 +65,7 @@ export async function translateWithGemini(
 	// gemini-2.5-flashモデルを使用（高速で安価、安定版）
 	const model = genAI.getGenerativeModel({
 		model: "gemini-2.5-flash",
-		systemInstruction:
-			"You are a professional translator. Translate the given Japanese text to natural English. Return only the translated text without any explanations or additional commentary.",
+		systemInstruction: SYSTEM_INSTRUCTION_BY_LANGUAGE[targetLanguage],
 	});
 
 	try {
@@ -77,36 +98,40 @@ export type GalleryTranslationInput = {
 };
 
 /**
- * ギャラリー画像の翻訳結果（日本語と英語）
+ * 1言語分の翻訳（タイトルと説明）
+ */
+type GalleryTranslationText = {
+	title: string | null;
+	description: string | null;
+};
+
+/**
+ * ギャラリー画像の翻訳結果（日本語・英語・スペイン語）
  */
 export type GalleryTranslationResult = {
-	/** 日本語翻訳 */
-	ja: {
-		title: string | null;
-		description: string | null;
-	};
+	/** 日本語翻訳（原文） */
+	ja: GalleryTranslationText;
 	/** 英語翻訳 */
-	en: {
-		title: string | null;
-		description: string | null;
-	};
+	en: GalleryTranslationText;
+	/** スペイン語翻訳 */
+	es: GalleryTranslationText;
 };
 
 /**
  * ギャラリー画像の翻訳データを生成
  *
  * @description
- * 日本語のタイトルと説明を受け取り、Gemini APIで英語に翻訳する。
- * 日本語と英語の両方の翻訳データを返す。
+ * 日本語のタイトルと説明を受け取り、Gemini APIで英語とスペイン語に翻訳する。
+ * 日本語（原文）・英語・スペイン語の翻訳データを返す。
  *
  * 処理フロー:
  * 1. 日本語のタイトルと説明を受け取る
- * 2. それぞれをGemini APIで英語に翻訳
- * 3. 日本語と英語の翻訳データを返す
+ * 2. それぞれをGemini APIで英語・スペイン語に並行翻訳する
+ * 3. 日本語・英語・スペイン語の翻訳データを返す
  *
  * @param input - 日本語の翻訳データ
  * @param apiKey - Gemini API Key
- * @returns 日本語と英語の翻訳データ
+ * @returns 日本語・英語・スペイン語の翻訳データ
  *
  * @example
  * ```typescript
@@ -119,7 +144,8 @@ export type GalleryTranslationResult = {
  * );
  * // => {
  * //   ja: { title: "東京タワーの夕景", description: "..." },
- * //   en: { title: "Tokyo Tower at Sunset", description: "..." }
+ * //   en: { title: "Tokyo Tower at Sunset", description: "..." },
+ * //   es: { title: "Torre de Tokio al atardecer", description: "..." }
  * // }
  * ```
  */
@@ -131,11 +157,19 @@ export async function translateGalleryImage(
 	const titleJa = input.titleJa?.trim() || null;
 	const descriptionJa = input.descriptionJa?.trim() || null;
 
-	// タイトルと説明を並行翻訳
-	const [titleEn, descriptionEn] = await Promise.all([
-		titleJa ? translateWithGemini(titleJa, apiKey) : Promise.resolve(null),
+	// タイトルと説明を、英語・スペイン語それぞれについて並行翻訳する
+	const [titleEn, descriptionEn, titleEs, descriptionEs] = await Promise.all([
+		titleJa
+			? translateWithGemini(titleJa, apiKey, "en")
+			: Promise.resolve(null),
 		descriptionJa
-			? translateWithGemini(descriptionJa, apiKey)
+			? translateWithGemini(descriptionJa, apiKey, "en")
+			: Promise.resolve(null),
+		titleJa
+			? translateWithGemini(titleJa, apiKey, "es")
+			: Promise.resolve(null),
+		descriptionJa
+			? translateWithGemini(descriptionJa, apiKey, "es")
 			: Promise.resolve(null),
 	]);
 
@@ -147,6 +181,10 @@ export async function translateGalleryImage(
 		en: {
 			title: titleEn,
 			description: descriptionEn,
+		},
+		es: {
+			title: titleEs,
+			description: descriptionEs,
 		},
 	};
 }

--- a/apps/backend/src/routes/articles/handlers/create-article/create-article.test.ts
+++ b/apps/backend/src/routes/articles/handlers/create-article/create-article.test.ts
@@ -986,9 +986,16 @@ describe("POST /articles - 記事作成", () => {
 
 			// Assert
 			expect(res.status).toBe(201);
+			// 公開記事は英語とスペイン語の2言語に翻訳される
 			expect(mockTranslateArticle).toHaveBeenCalledWith(
 				"公開記事",
-				"公開コンテンツ"
+				"公開コンテンツ",
+				"en"
+			);
+			expect(mockTranslateArticle).toHaveBeenCalledWith(
+				"公開記事",
+				"公開コンテンツ",
+				"es"
 			);
 		});
 	});
@@ -1090,6 +1097,7 @@ describe("POST /articles - 記事作成", () => {
 				.mockReturnValueOnce(insertArticleMock) // 記事作成
 				.mockReturnValueOnce(insertTranslationJaMock) // 日本語翻訳
 				.mockReturnValueOnce(insertTranslationEnMock) // 英語翻訳
+				.mockReturnValueOnce(insertTranslationEnMock) // スペイン語翻訳（enモックを再利用）
 				.mockReturnValueOnce(insertGalleryImagesMock); // ギャラリー画像挿入
 
 			// Act
@@ -1113,9 +1121,9 @@ describe("POST /articles - 記事作成", () => {
 			expect(res.status).toBe(201);
 
 			// ギャラリー画像の挿入が呼ばれたことを確認
-			expect(mockDb.insert).toHaveBeenCalledTimes(4); // 記事 + 日本語翻訳 + 英語翻訳 + ギャラリー画像
+			expect(mockDb.insert).toHaveBeenCalledTimes(5); // 記事 + 日本語翻訳 + 英語翻訳 + スペイン語翻訳 + ギャラリー画像
 			// 最後の insert 呼び出しがギャラリー画像の挿入
-			const galleryImageInsertCall = mockDb.insert.mock.calls[3];
+			const galleryImageInsertCall = mockDb.insert.mock.calls[4];
 			expect(galleryImageInsertCall[0]).toEqual({}); // articleGalleryImages テーブル
 
 			// values が正しく呼ばれたことを確認
@@ -1218,6 +1226,7 @@ describe("POST /articles - 記事作成", () => {
 				.mockReturnValueOnce(insertArticleMock)
 				.mockReturnValueOnce(insertTranslationJaMock)
 				.mockReturnValueOnce(insertTranslationEnMock)
+				.mockReturnValueOnce(insertTranslationEnMock) // スペイン語翻訳（enモックを再利用）
 				.mockReturnValueOnce(insertGalleryImagesMock);
 
 			// Act
@@ -1347,6 +1356,7 @@ describe("POST /articles - 記事作成", () => {
 				.mockReturnValueOnce(insertArticleMock)
 				.mockReturnValueOnce(insertTranslationJaMock)
 				.mockReturnValueOnce(insertTranslationEnMock)
+				.mockReturnValueOnce(insertTranslationEnMock) // スペイン語翻訳（enモックを再利用）
 				.mockReturnValueOnce(insertGalleryImagesMock);
 
 			// Act
@@ -1467,6 +1477,7 @@ describe("POST /articles - 記事作成", () => {
 				.mockReturnValueOnce(insertArticleMock)
 				.mockReturnValueOnce(insertTranslationJaMock)
 				.mockReturnValueOnce(insertTranslationEnMock)
+				.mockReturnValueOnce(insertTranslationEnMock) // スペイン語翻訳（enモックを再利用）
 				.mockReturnValueOnce(insertGalleryImagesMock);
 
 			// Act
@@ -1578,7 +1589,8 @@ describe("POST /articles - 記事作成", () => {
 			mockDb.insert
 				.mockReturnValueOnce(insertArticleMock)
 				.mockReturnValueOnce(insertTranslationJaMock)
-				.mockReturnValueOnce(insertTranslationEnMock);
+				.mockReturnValueOnce(insertTranslationEnMock)
+				.mockReturnValueOnce(insertTranslationEnMock); // 日本語 + 英語 + スペイン語
 			// ギャラリー画像挿入は呼ばれない（空配列のため）
 
 			// Act
@@ -1601,7 +1613,7 @@ describe("POST /articles - 記事作成", () => {
 			expect(res.status).toBe(201);
 
 			// ギャラリー画像挿入は呼ばれない
-			expect(mockDb.insert).toHaveBeenCalledTimes(3); // 記事 + 日本語翻訳 + 英語翻訳のみ
+			expect(mockDb.insert).toHaveBeenCalledTimes(4); // 記事 + 日本語翻訳 + 英語翻訳 + スペイン語翻訳
 		});
 
 		it("should work when content has no image URLs", async () => {
@@ -1681,7 +1693,8 @@ describe("POST /articles - 記事作成", () => {
 			mockDb.insert
 				.mockReturnValueOnce(insertArticleMock)
 				.mockReturnValueOnce(insertTranslationJaMock)
-				.mockReturnValueOnce(insertTranslationEnMock);
+				.mockReturnValueOnce(insertTranslationEnMock)
+				.mockReturnValueOnce(insertTranslationEnMock); // 日本語 + 英語 + スペイン語
 			// ギャラリー画像挿入は呼ばれない（画像URLがないため）
 
 			// Act
@@ -1703,7 +1716,7 @@ describe("POST /articles - 記事作成", () => {
 			expect(res.status).toBe(201);
 
 			// ギャラリー画像挿入は呼ばれない
-			expect(mockDb.insert).toHaveBeenCalledTimes(3); // 記事 + 日本語翻訳 + 英語翻訳のみ
+			expect(mockDb.insert).toHaveBeenCalledTimes(4); // 記事 + 日本語翻訳 + 英語翻訳 + スペイン語翻訳
 		});
 	});
 });

--- a/apps/backend/src/routes/articles/handlers/create-article/create-article.test.ts
+++ b/apps/backend/src/routes/articles/handlers/create-article/create-article.test.ts
@@ -17,6 +17,9 @@ vi.mock("@/services/gemini-translation/gemini-translation", () => ({
 	createTranslationService: vi.fn(() => ({
 		translateArticle: mockTranslateArticle,
 	})),
+	// ハンドラが翻訳対象言語の導出に使う定数。実値と同じ en・es を渡す。
+	TARGET_LANGUAGES: ["en", "es"] as const,
+	TARGET_LANGUAGE_NAMES: { en: "英語", es: "スペイン語" },
 }));
 
 // モック設定

--- a/apps/backend/src/routes/articles/handlers/create-article/create-article.ts
+++ b/apps/backend/src/routes/articles/handlers/create-article/create-article.ts
@@ -8,7 +8,10 @@ import {
 	buildContributionText,
 	recordArticleContribution,
 } from "@/lib/record-article-contribution";
-import { createTranslationService } from "@/services/gemini-translation/gemini-translation";
+import {
+	createTranslationService,
+	TARGET_LANGUAGES,
+} from "@/services/gemini-translation/gemini-translation";
 
 import type { createArticleRoute } from "./create-article.openapi";
 
@@ -107,9 +110,9 @@ export const createArticle: Handler = async (c) => {
 		}
 
 		// 6. 各対応言語への自動翻訳を実行（公開記事の場合のみ）
-		// 日本語（ja）は原文なので翻訳対象外。en・es を Gemini で生成する。
+		// 日本語（ja）は原文なので翻訳対象外。翻訳先は TARGET_LANGUAGES（en・es…）から導出するため、
+		// 対応言語を増やしても create-article 側の変更は不要。
 		// 1言語の翻訳が失敗しても他言語の保存は続行できるよう、言語ごとに独立してエラーを握りつぶす。
-		const AUTO_TRANSLATE_TARGET_LANGUAGES = ["en", "es"] as const;
 		if (status === "published" && c.env.GEMINI_API_KEY) {
 			const translationService = createTranslationService({
 				GEMINI_API_KEY: c.env.GEMINI_API_KEY,
@@ -117,7 +120,7 @@ export const createArticle: Handler = async (c) => {
 
 			// 各言語を並列で翻訳し、成功したものだけ保存する
 			await Promise.all(
-				AUTO_TRANSLATE_TARGET_LANGUAGES.map(async (targetLanguage) => {
+				TARGET_LANGUAGES.map(async (targetLanguage) => {
 					try {
 						const translatedArticle = await translationService.translateArticle(
 							title,

--- a/apps/backend/src/routes/articles/handlers/create-article/create-article.ts
+++ b/apps/backend/src/routes/articles/handlers/create-article/create-article.ts
@@ -106,37 +106,49 @@ export const createArticle: Handler = async (c) => {
 			});
 		}
 
-		// 6. 英語への自動翻訳を実行（公開記事の場合のみ）
+		// 6. 各対応言語への自動翻訳を実行（公開記事の場合のみ）
+		// 日本語（ja）は原文なので翻訳対象外。en・es を Gemini で生成する。
+		// 1言語の翻訳が失敗しても他言語の保存は続行できるよう、言語ごとに独立してエラーを握りつぶす。
+		const AUTO_TRANSLATE_TARGET_LANGUAGES = ["en", "es"] as const;
 		if (status === "published" && c.env.GEMINI_API_KEY) {
-			try {
-				const translationService = createTranslationService({
-					GEMINI_API_KEY: c.env.GEMINI_API_KEY,
-				});
+			const translationService = createTranslationService({
+				GEMINI_API_KEY: c.env.GEMINI_API_KEY,
+			});
 
-				// 翻訳を実行
-				const translatedArticle = await translationService.translateArticle(
-					title,
-					content
-				);
+			// 各言語を並列で翻訳し、成功したものだけ保存する
+			await Promise.all(
+				AUTO_TRANSLATE_TARGET_LANGUAGES.map(async (targetLanguage) => {
+					try {
+						const translatedArticle = await translationService.translateArticle(
+							title,
+							content,
+							targetLanguage
+						);
 
-				if (translatedArticle) {
-					// 英語版を保存
-					await db.insert(articleTranslations).values({
-						articleId: newArticle.id,
-						language: "en",
-						title: translatedArticle.title,
-						content: translatedArticle.content,
-					});
-					console.log(`Article ${newArticle.id} translated successfully`);
-				} else {
-					console.warn(
-						`Translation failed for article ${newArticle.id}, continuing without translation`
-					);
-				}
-			} catch (error) {
-				// 翻訳エラーが発生してもメインの処理は続行
-				console.error(`Translation error for article ${newArticle.id}:`, error);
-			}
+						if (translatedArticle) {
+							await db.insert(articleTranslations).values({
+								articleId: newArticle.id,
+								language: targetLanguage,
+								title: translatedArticle.title,
+								content: translatedArticle.content,
+							});
+							console.log(
+								`Article ${newArticle.id} translated to ${targetLanguage} successfully`
+							);
+						} else {
+							console.warn(
+								`Translation to ${targetLanguage} failed for article ${newArticle.id}, continuing without it`
+							);
+						}
+					} catch (error) {
+						// 翻訳エラーが発生してもメインの処理は続行
+						console.error(
+							`Translation to ${targetLanguage} error for article ${newArticle.id}:`,
+							error
+						);
+					}
+				})
+			);
 		} else if (status === "draft") {
 			console.log(`Article ${newArticle.id} is a draft, skipping translation`);
 		} else {

--- a/apps/backend/src/routes/articles/handlers/get-all-articles/get-all-articles.openapi.ts
+++ b/apps/backend/src/routes/articles/handlers/get-all-articles/get-all-articles.openapi.ts
@@ -12,7 +12,7 @@ const articlesOpenApiQuerySchema = z.object({
 		example: "10",
 		description: "1ページあたりの記事数",
 	}),
-	language: z.enum(["ja", "en"]).optional().openapi({
+	language: z.enum(["ja", "en", "es"]).optional().openapi({
 		example: "ja",
 		description: "言語",
 	}),

--- a/apps/backend/src/routes/articles/handlers/get-article-by-id/get-article-by-id.openapi.ts
+++ b/apps/backend/src/routes/articles/handlers/get-article-by-id/get-article-by-id.openapi.ts
@@ -134,7 +134,7 @@ export const getArticleByIdRoute = createRoute({
 			}),
 		}),
 		query: z.object({
-			lang: z.enum(["ja", "en"]).optional().default("ja").openapi({
+			lang: z.enum(["ja", "en", "es"]).optional().default("ja").openapi({
 				example: "ja",
 				description: "言語",
 			}),

--- a/apps/backend/src/routes/articles/handlers/get-article/get-article.openapi.ts
+++ b/apps/backend/src/routes/articles/handlers/get-article/get-article.openapi.ts
@@ -117,7 +117,7 @@ const ArticleParamSchema = z.object({
  * 記事詳細クエリスキーマ
  */
 const ArticleDetailQuerySchema = z.object({
-	lang: z.enum(["ja", "en"]).optional().openapi({
+	lang: z.enum(["ja", "en", "es"]).optional().openapi({
 		example: "ja",
 		description: "言語",
 	}),

--- a/apps/backend/src/routes/articles/handlers/get-related-articles/get-related-articles.openapi.ts
+++ b/apps/backend/src/routes/articles/handlers/get-related-articles/get-related-articles.openapi.ts
@@ -4,7 +4,7 @@ import { createRoute, z } from "@hono/zod-openapi";
  * OpenAPI用クエリパラメータスキーマ
  */
 const relatedArticlesQuerySchema = z.object({
-	language: z.enum(["ja", "en"]).optional().openapi({
+	language: z.enum(["ja", "en", "es"]).optional().openapi({
 		example: "ja",
 		description: "言語",
 	}),

--- a/apps/backend/src/routes/articles/handlers/get-suggestions/get-suggestions.openapi.ts
+++ b/apps/backend/src/routes/articles/handlers/get-suggestions/get-suggestions.openapi.ts
@@ -38,7 +38,7 @@ export const ArticleSuggestionsQuerySchema = z.object({
 		example: "Next",
 		description: "検索クエリ文字列（空文字列の場合は全記事を取得）",
 	}),
-	lang: z.enum(["ja", "en"]).optional().default("ja").openapi({
+	lang: z.enum(["ja", "en", "es"]).optional().default("ja").openapi({
 		example: "ja",
 		description: "表示言語",
 	}),

--- a/apps/backend/src/routes/articles/handlers/update-article/update-article.test.ts
+++ b/apps/backend/src/routes/articles/handlers/update-article/update-article.test.ts
@@ -182,7 +182,7 @@ describe("PUT /articles/:id - 記事更新", () => {
 
 		expect(mockDb.update).toHaveBeenCalledTimes(1); // 記事の更新
 		expect(mockDb.delete).toHaveBeenCalledTimes(2); // タグ削除 + ギャラリー画像削除
-		expect(mockDb.insert).toHaveBeenCalledTimes(3); // 日本語翻訳のUpsert + 英語翻訳のUpsert + タグ追加
+		expect(mockDb.insert).toHaveBeenCalledTimes(4); // 日本語翻訳 + 英語翻訳 + スペイン語翻訳 + タグ追加
 	});
 
 	it("存在しないIDの場合、404エラーを返す", async () => {
@@ -400,12 +400,18 @@ describe("PUT /articles/:id - 記事更新", () => {
 
 			// 改善後の検証: UPDATEは1回（記事のみ）、翻訳はINSERTでUpsert
 			expect(mockDb.update).toHaveBeenCalledTimes(1);
-			expect(mockDb.insert).toHaveBeenCalledTimes(3); // タグ追加 + 日本語翻訳 + 英語翻訳
+			expect(mockDb.insert).toHaveBeenCalledTimes(4); // タグ追加 + 日本語翻訳 + 英語翻訳 + スペイン語翻訳
 
-			// 翻訳サービスが呼ばれたことを確認
+			// 翻訳サービスが英語・スペイン語の2言語で呼ばれたことを確認
 			expect(mockTranslateArticle).toHaveBeenCalledWith(
 				"更新された記事",
-				"これは更新された内容です。"
+				"これは更新された内容です。",
+				"en"
+			);
+			expect(mockTranslateArticle).toHaveBeenCalledWith(
+				"更新された記事",
+				"これは更新された内容です。",
+				"es"
 			);
 		});
 
@@ -1137,7 +1143,8 @@ describe("PUT /articles/:id - 記事更新", () => {
 			mockDb.update.mockReturnValueOnce(updateMock);
 			mockDb.insert
 				.mockReturnValueOnce(upsertJaMock)
-				.mockReturnValueOnce(upsertEnMock);
+				.mockReturnValueOnce(upsertEnMock)
+				.mockReturnValueOnce(upsertEnMock); // スペイン語翻訳Upsert（enモック再利用）
 			mockDb.delete
 				.mockReturnValueOnce(deleteMock) // タグ削除
 				.mockReturnValueOnce(deleteMock); // ギャラリー画像削除
@@ -1160,9 +1167,16 @@ describe("PUT /articles/:id - 記事更新", () => {
 
 			// Assert
 			expect(res.status).toBe(200);
+			// 公開記事は英語とスペイン語の2言語に翻訳される
 			expect(mockTranslateArticle).toHaveBeenCalledWith(
 				"公開記事",
-				"公開コンテンツ"
+				"公開コンテンツ",
+				"en"
+			);
+			expect(mockTranslateArticle).toHaveBeenCalledWith(
+				"公開記事",
+				"公開コンテンツ",
+				"es"
 			);
 		});
 	});
@@ -1267,6 +1281,7 @@ describe("PUT /articles/:id - 記事更新", () => {
 			mockDb.insert
 				.mockReturnValueOnce(upsertJaMock) // 日本語翻訳Upsert
 				.mockReturnValueOnce(upsertEnMock) // 英語翻訳Upsert
+				.mockReturnValueOnce(upsertEnMock) // スペイン語翻訳Upsert（enモック再利用）
 				.mockReturnValueOnce(insertMock); // ギャラリー画像挿入
 
 			mockDb.delete
@@ -1295,9 +1310,9 @@ describe("PUT /articles/:id - 記事更新", () => {
 			expect(res.status).toBe(200);
 
 			// ギャラリー画像の挿入が呼ばれたことを確認
-			expect(mockDb.insert).toHaveBeenCalledTimes(3); // 日本語翻訳 + 英語翻訳 + ギャラリー画像
+			expect(mockDb.insert).toHaveBeenCalledTimes(4); // 日本語翻訳 + 英語翻訳 + スペイン語翻訳 + ギャラリー画像
 			// 最後の insert 呼び出しがギャラリー画像の挿入
-			const galleryImageInsertCall = mockDb.insert.mock.calls[2];
+			const galleryImageInsertCall = mockDb.insert.mock.calls[3];
 			expect(galleryImageInsertCall[0]).toEqual({}); // articleGalleryImages テーブル
 
 			// values が正しく呼ばれたことを確認
@@ -1402,6 +1417,7 @@ describe("PUT /articles/:id - 記事更新", () => {
 			mockDb.insert
 				.mockReturnValueOnce(upsertJaMock)
 				.mockReturnValueOnce(upsertEnMock)
+				.mockReturnValueOnce(upsertEnMock) // スペイン語翻訳Upsert（enモック再利用）
 				.mockReturnValueOnce(insertMock);
 
 			mockDb.delete
@@ -1538,6 +1554,7 @@ describe("PUT /articles/:id - 記事更新", () => {
 			mockDb.insert
 				.mockReturnValueOnce(upsertJaMock)
 				.mockReturnValueOnce(upsertEnMock)
+				.mockReturnValueOnce(upsertEnMock) // スペイン語翻訳Upsert（enモック再利用）
 				.mockReturnValueOnce(insertMock);
 
 			mockDb.delete
@@ -1665,6 +1682,7 @@ describe("PUT /articles/:id - 記事更新", () => {
 			mockDb.insert
 				.mockReturnValueOnce(upsertJaMock)
 				.mockReturnValueOnce(upsertEnMock)
+				.mockReturnValueOnce(upsertEnMock) // スペイン語翻訳Upsert（enモック再利用）
 				.mockReturnValueOnce(insertMock);
 
 			mockDb.delete
@@ -1783,7 +1801,8 @@ describe("PUT /articles/:id - 記事更新", () => {
 			mockDb.update.mockReturnValue(updateMock);
 			mockDb.insert
 				.mockReturnValueOnce(upsertJaMock)
-				.mockReturnValueOnce(upsertEnMock);
+				.mockReturnValueOnce(upsertEnMock)
+				.mockReturnValueOnce(upsertEnMock); // スペイン語翻訳Upsert（enモック再利用）
 			// ギャラリー画像挿入は呼ばれない（空配列のため）
 
 			mockDb.delete
@@ -1811,7 +1830,7 @@ describe("PUT /articles/:id - 記事更新", () => {
 			expect(res.status).toBe(200);
 
 			// ギャラリー画像挿入は呼ばれない
-			expect(mockDb.insert).toHaveBeenCalledTimes(2); // 日本語翻訳 + 英語翻訳のみ
+			expect(mockDb.insert).toHaveBeenCalledTimes(3); // 日本語翻訳 + 英語翻訳 + スペイン語翻訳のみ
 		});
 
 		it("should work when content has no image URLs", async () => {
@@ -1892,7 +1911,8 @@ describe("PUT /articles/:id - 記事更新", () => {
 			mockDb.update.mockReturnValue(updateMock);
 			mockDb.insert
 				.mockReturnValueOnce(upsertJaMock)
-				.mockReturnValueOnce(upsertEnMock);
+				.mockReturnValueOnce(upsertEnMock)
+				.mockReturnValueOnce(upsertEnMock); // スペイン語翻訳Upsert（enモック再利用）
 			// ギャラリー画像挿入は呼ばれない（画像URLがないため）
 
 			mockDb.delete
@@ -1919,7 +1939,7 @@ describe("PUT /articles/:id - 記事更新", () => {
 			expect(res.status).toBe(200);
 
 			// ギャラリー画像挿入は呼ばれない
-			expect(mockDb.insert).toHaveBeenCalledTimes(2); // 日本語翻訳 + 英語翻訳のみ
+			expect(mockDb.insert).toHaveBeenCalledTimes(3); // 日本語翻訳 + 英語翻訳 + スペイン語翻訳のみ
 		});
 	});
 });

--- a/apps/backend/src/routes/articles/handlers/update-article/update-article.test.ts
+++ b/apps/backend/src/routes/articles/handlers/update-article/update-article.test.ts
@@ -17,6 +17,9 @@ vi.mock("@/services/gemini-translation/gemini-translation", () => ({
 	createTranslationService: vi.fn(() => ({
 		translateArticle: mockTranslateArticle,
 	})),
+	// ハンドラが翻訳対象言語の導出に使う定数。実値と同じ en・es を渡す。
+	TARGET_LANGUAGES: ["en", "es"] as const,
+	TARGET_LANGUAGE_NAMES: { en: "英語", es: "スペイン語" },
 }));
 
 // モック設定

--- a/apps/backend/src/routes/articles/handlers/update-article/update-article.ts
+++ b/apps/backend/src/routes/articles/handlers/update-article/update-article.ts
@@ -167,61 +167,73 @@ export const updateArticle: Handler = async (c) => {
 			});
 		}
 
-		// 7. 英語への自動翻訳を実行（公開記事の場合のみ）
+		// 7. 各対応言語への自動翻訳を実行（公開記事の場合のみ）
+		// 日本語（ja）は原文なので翻訳対象外。en・es を Gemini で生成する。
 		const warnings: Array<{ code: string; message: string }> = [];
+		// 翻訳先の言語コードと、警告メッセージ用の日本語表示名の対応
+		const AUTO_TRANSLATE_TARGETS = [
+			{ language: "en", label: "英語" },
+			{ language: "es", label: "スペイン語" },
+		] as const;
 
 		if (status === "published") {
-			try {
-				const translationService = createTranslationService({
-					GEMINI_API_KEY: c.env.GEMINI_API_KEY,
-				});
+			const translationService = createTranslationService({
+				GEMINI_API_KEY: c.env.GEMINI_API_KEY,
+			});
 
-				// 記事を翻訳
-				const translatedArticle = await translationService.translateArticle(
-					title,
-					content
-				);
+			// 各言語を並列で翻訳し、Upsert する。1言語が失敗しても他言語は続行する。
+			await Promise.all(
+				AUTO_TRANSLATE_TARGETS.map(async ({ language, label }) => {
+					try {
+						const translatedArticle = await translationService.translateArticle(
+							title,
+							content,
+							language
+						);
 
-				if (translatedArticle) {
-					// 英語版をUpsert
-					// レコードがない場合は新規作成、ある場合は更新
-					await db
-						.insert(articleTranslations)
-						.values({
-							articleId,
-							language: "en",
-							title: translatedArticle.title,
-							content: translatedArticle.content,
-						})
-						.onConflictDoUpdate({
-							target: [
-								articleTranslations.articleId,
-								articleTranslations.language,
-							],
-							set: {
-								title: translatedArticle.title,
-								content: translatedArticle.content,
-							},
+						if (translatedArticle) {
+							// レコードがない場合は新規作成、ある場合は更新
+							await db
+								.insert(articleTranslations)
+								.values({
+									articleId,
+									language,
+									title: translatedArticle.title,
+									content: translatedArticle.content,
+								})
+								.onConflictDoUpdate({
+									target: [
+										articleTranslations.articleId,
+										articleTranslations.language,
+									],
+									set: {
+										title: translatedArticle.title,
+										content: translatedArticle.content,
+									},
+								});
+						} else {
+							warnings.push({
+								code: "TRANSLATION_FAILED",
+								message: `${label}への自動翻訳に失敗しました。記事の更新は正常に完了しています。`,
+							});
+						}
+					} catch (error) {
+						// 翻訳エラーが発生してもメインの処理は続行
+						console.error(
+							`Translation to ${language} error for article ${articleId}:`,
+							error
+						);
+						const errorMessage =
+							error instanceof Error
+								? error.message
+								: `${label}への自動翻訳中にエラーが発生しました`;
+						warnings.push({
+							code: "TRANSLATION_FAILED",
+							message: `${errorMessage}。記事の更新は正常に完了しています。`,
 						});
-				} else {
-					warnings.push({
-						code: "TRANSLATION_FAILED",
-						message:
-							"英語への自動翻訳に失敗しました。記事の更新は正常に完了しています。",
-					});
-				}
-			} catch (error) {
-				// 翻訳エラーが発生してもメインの処理は続行
-				console.error(`Translation error for article ${articleId}:`, error);
-				const errorMessage =
-					error instanceof Error
-						? error.message
-						: "英語への自動翻訳中にエラーが発生しました";
-				warnings.push({
-					code: "TRANSLATION_FAILED",
-					message: `${errorMessage}。記事の更新は正常に完了しています。`,
-				});
-			}
+					}
+				})
+			);
 		} else if (status === "draft") {
 			console.log(`Article ${articleId} is a draft, skipping translation`);
 		}

--- a/apps/backend/src/routes/articles/handlers/update-article/update-article.ts
+++ b/apps/backend/src/routes/articles/handlers/update-article/update-article.ts
@@ -8,7 +8,11 @@ import {
 	buildContributionText,
 	recordArticleContribution,
 } from "@/lib/record-article-contribution";
-import { createTranslationService } from "@/services/gemini-translation/gemini-translation";
+import {
+	createTranslationService,
+	TARGET_LANGUAGE_NAMES,
+	TARGET_LANGUAGES,
+} from "@/services/gemini-translation/gemini-translation";
 
 import type { updateArticleRoute } from "./update-article.openapi";
 
@@ -168,13 +172,14 @@ export const updateArticle: Handler = async (c) => {
 		}
 
 		// 7. 各対応言語への自動翻訳を実行（公開記事の場合のみ）
-		// 日本語（ja）は原文なので翻訳対象外。en・es を Gemini で生成する。
+		// 日本語（ja）は原文なので翻訳対象外。翻訳先は TARGET_LANGUAGES から導出し、
+		// 警告メッセージ用の日本語表示名は TARGET_LANGUAGE_NAMES から引く。
+		// これにより対応言語を増やしても update-article 側の変更は不要。
 		const warnings: Array<{ code: string; message: string }> = [];
-		// 翻訳先の言語コードと、警告メッセージ用の日本語表示名の対応
-		const AUTO_TRANSLATE_TARGETS = [
-			{ language: "en", label: "英語" },
-			{ language: "es", label: "スペイン語" },
-		] as const;
+		const AUTO_TRANSLATE_TARGETS = TARGET_LANGUAGES.map((language) => ({
+			language,
+			label: TARGET_LANGUAGE_NAMES[language],
+		}));
 
 		if (status === "published") {
 			const translationService = createTranslationService({

--- a/apps/backend/src/routes/articles/schema.ts
+++ b/apps/backend/src/routes/articles/schema.ts
@@ -76,7 +76,7 @@ export const ArticleSuggestionsQuerySchema = z.object({
 		description: "検索クエリ文字列",
 	}),
 	/** 言語 */
-	lang: z.enum(["ja", "en"]).optional().default("ja").openapi({
+	lang: z.enum(["ja", "en", "es"]).optional().default("ja").openapi({
 		example: "ja",
 		description: "表示言語",
 	}),
@@ -160,7 +160,7 @@ export const ArticleCheckSlugResponseSchema = z.object({
 export const ArticlesQuerySchema = z.object({
 	page: z.string().regex(/^\d+$/).optional().default("1"),
 	limit: z.string().regex(/^\d+$/).optional().default("10"),
-	language: z.enum(["ja", "en"]).optional().default("ja"),
+	language: z.enum(["ja", "en", "es"]).optional().default("ja"),
 	status: z.enum(["all", "draft", "published", "archived"]).optional(),
 	search: z.string().optional(),
 	sortBy: z.string().optional(),
@@ -206,7 +206,7 @@ export const ArticleDetailParamSchema = z.object({
  * 記事詳細取得のクエリパラメータスキーマ
  */
 export const ArticleDetailQuerySchema = z.object({
-	lang: z.enum(["ja", "en"]).optional().default("ja").openapi({
+	lang: z.enum(["ja", "en", "es"]).optional().default("ja").openapi({
 		example: "ja",
 		description: "表示言語",
 	}),

--- a/apps/backend/src/routes/dashboard/handlers/get-overview/get-overview.openapi.ts
+++ b/apps/backend/src/routes/dashboard/handlers/get-overview/get-overview.openapi.ts
@@ -121,7 +121,7 @@ export const getDashboardOverviewRoute = createRoute({
 	path: "/overview",
 	request: {
 		query: z.object({
-			language: z.enum(["ja", "en"]).optional().openapi({
+			language: z.enum(["ja", "en", "es"]).optional().openapi({
 				example: "ja",
 				description: "統計データを取得する言語",
 			}),

--- a/apps/backend/src/routes/dashboard/handlers/get-stats/get-stats.openapi.ts
+++ b/apps/backend/src/routes/dashboard/handlers/get-stats/get-stats.openapi.ts
@@ -4,7 +4,7 @@ import { createRoute, z } from "@hono/zod-openapi";
  * OpenAPI用のクエリスキーマ
  */
 const dashboardStatsOpenApiQuerySchema = z.object({
-	language: z.enum(["ja", "en"]).optional().openapi({
+	language: z.enum(["ja", "en", "es"]).optional().openapi({
 		example: "ja",
 		description: "統計データを取得する言語",
 	}),

--- a/apps/backend/src/routes/dashboard/handlers/get-views-trend/get-views-trend.openapi.ts
+++ b/apps/backend/src/routes/dashboard/handlers/get-views-trend/get-views-trend.openapi.ts
@@ -4,7 +4,7 @@ import { createRoute, z } from "@hono/zod-openapi";
  * 閲覧数推移用のOpenAPIクエリスキーマ
  */
 const viewsTrendOpenApiQuerySchema = z.object({
-	language: z.enum(["ja", "en"]).optional().openapi({
+	language: z.enum(["ja", "en", "es"]).optional().openapi({
 		example: "ja",
 		description: "統計データを取得する言語",
 	}),

--- a/apps/backend/src/routes/gallery/handlers/get-admin-gallery-images/get-admin-gallery-images.openapi.ts
+++ b/apps/backend/src/routes/gallery/handlers/get-admin-gallery-images/get-admin-gallery-images.openapi.ts
@@ -6,7 +6,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 const GalleryImageTranslationSchema = z.object({
 	id: z.number(),
 	galleryImageId: z.number(),
-	language: z.enum(["ja", "en"]),
+	language: z.enum(["ja", "en", "es"]),
 	title: z.string().nullable(),
 	description: z.string().nullable(),
 	createdAt: z.string(),

--- a/apps/backend/src/routes/gallery/handlers/get-gallery-image-by-id/get-gallery-image-by-id.openapi.ts
+++ b/apps/backend/src/routes/gallery/handlers/get-gallery-image-by-id/get-gallery-image-by-id.openapi.ts
@@ -6,7 +6,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 const GalleryImageTranslationSchema = z.object({
 	id: z.number(),
 	galleryImageId: z.number(),
-	language: z.enum(["ja", "en"]),
+	language: z.enum(["ja", "en", "es"]),
 	title: z.string().nullable(),
 	description: z.string().nullable(),
 	createdAt: z.string(),
@@ -68,7 +68,7 @@ export const getGalleryImageByIdRoute = createRoute({
 			}),
 		}),
 		query: z.object({
-			language: z.enum(["ja", "en"]).optional().openapi({
+			language: z.enum(["ja", "en", "es"]).optional().openapi({
 				example: "ja",
 				description:
 					"言語指定（オプショナル）。指定された場合、その言語の翻訳のみを返す",

--- a/apps/backend/src/routes/gallery/handlers/get-gallery-images/get-gallery-images.openapi.ts
+++ b/apps/backend/src/routes/gallery/handlers/get-gallery-images/get-gallery-images.openapi.ts
@@ -6,7 +6,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 const GalleryImageTranslationSchema = z.object({
 	id: z.number(),
 	galleryImageId: z.number(),
-	language: z.enum(["ja", "en"]),
+	language: z.enum(["ja", "en", "es"]),
 	title: z.string().nullable(),
 	description: z.string().nullable(),
 	createdAt: z.string(),

--- a/apps/backend/src/routes/gallery/handlers/update-gallery-image/update-gallery-image.openapi.ts
+++ b/apps/backend/src/routes/gallery/handlers/update-gallery-image/update-gallery-image.openapi.ts
@@ -4,7 +4,7 @@ import { createRoute, z } from "@hono/zod-openapi";
  * 翻訳データスキーマ
  */
 const TranslationSchema = z.object({
-	language: z.enum(["ja", "en"]).openapi({
+	language: z.enum(["ja", "en", "es"]).openapi({
 		example: "ja",
 		description: "言語コード",
 	}),
@@ -89,7 +89,7 @@ const GalleryImageSchema = z.object({
 		z.object({
 			id: z.number(),
 			galleryImageId: z.number(),
-			language: z.enum(["ja", "en"]),
+			language: z.enum(["ja", "en", "es"]),
 			title: z.string().nullable(),
 			description: z.string().nullable(),
 			createdAt: z.string(),

--- a/apps/backend/src/routes/gallery/handlers/upload-gallery-image/upload-gallery-image.test.ts
+++ b/apps/backend/src/routes/gallery/handlers/upload-gallery-image/upload-gallery-image.test.ts
@@ -66,6 +66,10 @@ describe("Unit Test", () => {
 					title: "Test Title",
 					description: "Test Description",
 				},
+				es: {
+					title: "Título de prueba",
+					description: "Descripción de prueba",
+				},
 			});
 
 			mockUploadImage.mockResolvedValue({

--- a/apps/backend/src/routes/gallery/handlers/upload-gallery-image/upload-gallery-image.ts
+++ b/apps/backend/src/routes/gallery/handlers/upload-gallery-image/upload-gallery-image.ts
@@ -232,6 +232,18 @@ export const uploadGalleryImageHandler: Handler = async (c) => {
 			});
 		}
 
+		// スペイン語の翻訳データ
+		if (translationResult.es.title || translationResult.es.description) {
+			translationsToInsert.push({
+				galleryImageId: newGalleryImage.id,
+				language: "es" as const,
+				title: translationResult.es.title,
+				description: translationResult.es.description,
+				createdAt: now,
+				updatedAt: now,
+			});
+		}
+
 		if (translationsToInsert.length > 0) {
 			await db.insert(galleryImageTranslations).values(translationsToInsert);
 		}

--- a/apps/backend/src/routes/geocoding/handlers/search-geocoding/search-geocoding.openapi.ts
+++ b/apps/backend/src/routes/geocoding/handlers/search-geocoding/search-geocoding.openapi.ts
@@ -13,7 +13,7 @@ const SearchGeocodingQuerySchema = z.object({
 	/**
 	 * 言語コード（ja, en）
 	 */
-	language: z.enum(["ja", "en"]).optional().openapi({
+	language: z.enum(["ja", "en", "es"]).optional().openapi({
 		example: "ja",
 	}),
 	/**

--- a/apps/backend/src/routes/public/handlers/get-contributions/get-contributions.openapi.ts
+++ b/apps/backend/src/routes/public/handlers/get-contributions/get-contributions.openapi.ts
@@ -29,7 +29,7 @@ export const getPublicContributionsRoute = createRoute({
 				example: "365",
 				description: "日数。30/90/180/365 のいずれか",
 			}),
-			locale: z.enum(["ja", "en"]).optional().openapi({
+			locale: z.enum(["ja", "en", "es"]).optional().openapi({
 				example: "ja",
 				description: "UI向けの言語（レスポンス内容は同じ）",
 			}),

--- a/apps/backend/src/scripts/backfill-es-translations.test.ts
+++ b/apps/backend/src/scripts/backfill-es-translations.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import { pickMissing } from "./backfill-es-translations";
+
+/**
+ * pickMissing のテスト観点表（等価分割・境界値）
+ *
+ * | # | 観点                         | sources           | existingEsIds | 期待結果            |
+ * |---|------------------------------|-------------------|---------------|---------------------|
+ * | 1 | 一部に es あり（正常系）     | id 1,2,3          | [2]           | id 1,3              |
+ * | 2 | es が全く無い                | id 1,2            | []            | id 1,2（全件）      |
+ * | 3 | 全件に es あり               | id 1,2            | [1,2]         | []（空）            |
+ * | 4 | sources が空                 | []                | [1]           | []（空）            |
+ * | 5 | existingEsIds に重複         | id 1,2            | [1,1]         | id 2                |
+ * | 6 | existingEsIds に無関係な ID  | id 1,2            | [99]          | id 1,2（全件）      |
+ * | 7 | getId が別フィールドを参照   | galleryImageId    | [10]          | 該当以外            |
+ */
+
+type SourceRow = { articleId: number; title: string };
+
+const rows: SourceRow[] = [
+	{ articleId: 1, title: "A" },
+	{ articleId: 2, title: "B" },
+	{ articleId: 3, title: "C" },
+];
+
+describe("pickMissing", () => {
+	describe("Unit Test", () => {
+		it("returns only rows whose id is not in existingEsIds", () => {
+			// Given: id 2 だけ es が存在する
+			// When: pickMissing で欠けている行を抽出
+			const result = pickMissing(rows, [2], (row) => row.articleId);
+
+			// Then: id 1 と 3 が残る
+			expect(result).toEqual([
+				{ articleId: 1, title: "A" },
+				{ articleId: 3, title: "C" },
+			]);
+		});
+
+		it("returns all rows when no es exists yet", () => {
+			// Given: es が1件も存在しない
+			// When: 抽出
+			const result = pickMissing(rows, [], (row) => row.articleId);
+
+			// Then: 全件が対象になる
+			expect(result).toHaveLength(3);
+		});
+
+		it("returns an empty array when every row already has es", () => {
+			// Given: 全 id に es が存在する
+			// When: 抽出
+			const result = pickMissing(rows, [1, 2, 3], (row) => row.articleId);
+
+			// Then: 対象は空
+			expect(result).toEqual([]);
+		});
+
+		it("returns an empty array when sources is empty", () => {
+			// Given: ソースが空
+			// When: 抽出
+			const result = pickMissing<SourceRow>([], [1], (row) => row.articleId);
+
+			// Then: 空配列を返す
+			expect(result).toEqual([]);
+		});
+
+		it("treats duplicated existingEsIds the same as a single occurrence", () => {
+			// Given: existingEsIds に id 1 が重複して含まれる
+			// When: 抽出
+			const result = pickMissing(
+				[
+					{ articleId: 1, title: "A" },
+					{ articleId: 2, title: "B" },
+				],
+				[1, 1],
+				(row) => row.articleId
+			);
+
+			// Then: 重複は影響せず id 2 のみ残る
+			expect(result).toEqual([{ articleId: 2, title: "B" }]);
+		});
+
+		it("ignores existingEsIds that do not match any source", () => {
+			// Given: どのソースにも一致しない id 99
+			// When: 抽出
+			const result = pickMissing(
+				[
+					{ articleId: 1, title: "A" },
+					{ articleId: 2, title: "B" },
+				],
+				[99],
+				(row) => row.articleId
+			);
+
+			// Then: 除外されず全件が残る
+			expect(result).toHaveLength(2);
+		});
+
+		it("uses the provided getId accessor to read the id field", () => {
+			// Given: articleId ではなく galleryImageId を持つ行
+			const galleryRows = [
+				{ galleryImageId: 10, title: "X" },
+				{ galleryImageId: 20, title: "Y" },
+			];
+
+			// When: getId で galleryImageId を参照
+			const result = pickMissing(
+				galleryRows,
+				[10],
+				(row) => row.galleryImageId
+			);
+
+			// Then: id 10 が除外され 20 のみ残る
+			expect(result).toEqual([{ galleryImageId: 20, title: "Y" }]);
+		});
+	});
+});

--- a/apps/backend/src/scripts/backfill-es-translations.ts
+++ b/apps/backend/src/scripts/backfill-es-translations.ts
@@ -1,0 +1,493 @@
+/**
+ * 既存コンテンツにスペイン語（es）翻訳をバックフィルするスクリプト。
+ *
+ * @description
+ * サイトに es を追加したが、既存の記事・ギャラリー画像・タグには es 翻訳が無い。
+ * `get-article` ハンドラは `language = lang` を厳密一致で引くため、es 行が無い記事は
+ * `/es/blog/[slug]` で 404 になる。このスクリプトは既存の日本語（ja）コンテンツを走査し、
+ * 欠けている es 翻訳を Gemini で生成して埋める。
+ *
+ * 対象:
+ * - 記事: status = "published" のみ（既存の en 自動翻訳の挙動に合わせる）
+ * - ギャラリー画像: ja 翻訳を持つ全件
+ * - タグ: ja 翻訳を持つ全件（表示ラベル用途のため自然なスペイン語を生成する）
+ *
+ * 冪等性:
+ * - 記事・ギャラリーは (id, language) のユニーク制約があるため onConflictDoUpdate で再実行安全。
+ * - タグは (tagId, language) のユニーク制約が無いため、事前に既存 es を除外してから挿入する。
+ *
+ * 実行:
+ * - `pnpm --filter @saneatsu/backend db:backfill-es`
+ * - `... db:backfill-es -- --dry-run`   書き込まず対象件数のみ表示（本番前の確認用）
+ * - `... db:backfill-es -- --limit 3`    各種の先頭3件だけ処理（動作確認用）
+ *
+ * 環境変数（apps/backend/.env またはシェルの環境変数）:
+ * - GEMINI_API_KEY       翻訳に使用
+ * - TURSO_DATABASE_URL   ローカルは file:./local.db、本番は libsql://...
+ * - TURSO_AUTH_TOKEN     本番 Turso のみ必要
+ */
+
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+	articles,
+	articleTranslations,
+	createDatabaseClient,
+	galleryImages,
+	galleryImageTranslations,
+	tags,
+	tagTranslations,
+} from "@saneatsu/db";
+import dotenv from "dotenv";
+import { and, eq } from "drizzle-orm";
+
+import { translateWithGemini } from "../lib/translate";
+import { createTranslationService } from "../services/gemini-translation/gemini-translation";
+
+// ---------------------------------------------------------------------------
+// 型・ユーティリティ
+// ---------------------------------------------------------------------------
+
+/** createDatabaseClient が返す Drizzle クライアントの型 */
+type Db = ReturnType<typeof createDatabaseClient>;
+
+/** バックフィルの実行オプション */
+type BackfillOptions = {
+	/** true の場合は書き込まず、対象件数と ID のみ出力する */
+	dryRun: boolean;
+	/** 各種の処理件数上限（未指定なら全件） */
+	limit?: number;
+};
+
+/** 1種別ぶんの処理結果サマリー */
+type BackfillSummary = {
+	/** es が欠けていた（＝対象となった）件数 */
+	target: number;
+	/** 実際に翻訳・保存できた件数 */
+	done: number;
+	/** 翻訳失敗などでスキップした件数 */
+	skipped: number;
+};
+
+/**
+ * es が欠けているソース行だけを抽出する純粋関数
+ *
+ * @description
+ * ja 翻訳を持つソース行のうち、既に es 翻訳を持つ ID を除外する。
+ * DB アクセスを含まないため単体テストしやすい。
+ *
+ * @param sources - ja 翻訳を持つソース行の配列
+ * @param existingEsIds - 既に es 翻訳を持つ ID の配列
+ * @param getId - ソース行から対象 ID を取り出す関数
+ * @returns es 翻訳がまだ無いソース行のみの配列
+ */
+export function pickMissing<T>(
+	sources: T[],
+	existingEsIds: number[],
+	getId: (source: T) => number
+): T[] {
+	const existing = new Set(existingEsIds);
+	return sources.filter((source) => !existing.has(getId(source)));
+}
+
+/** 指定ミリ秒だけ待機する（Gemini のレート制限対策） */
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Gemini 呼び出し間の待機時間（ミリ秒）。translateBatch の実装に倣う。 */
+const RATE_LIMIT_DELAY_MS = 1000;
+
+/** limit オプションを適用して先頭 n 件に絞る */
+function applyLimit<T>(items: T[], limit?: number): T[] {
+	return typeof limit === "number" ? items.slice(0, limit) : items;
+}
+
+// ---------------------------------------------------------------------------
+// 記事（published のみ）
+// ---------------------------------------------------------------------------
+
+/**
+ * 公開記事の es 翻訳をバックフィルする
+ *
+ * 処理フロー:
+ * 1. published 記事の ja タイトル・本文を取得
+ * 2. 既に es 翻訳を持つ記事 ID を取得し、欠けているものだけに絞る
+ * 3. dry-run ならログのみ返す
+ * 4. 各記事を Gemini で es に翻訳（失敗時は null なのでスキップ）
+ * 5. (articleId, language) をキーに upsert（冪等）
+ */
+async function backfillArticles(
+	db: Db,
+	apiKey: string,
+	options: BackfillOptions
+): Promise<BackfillSummary> {
+	// 1. published 記事の ja 本文を取得
+	const jaRows = await db
+		.select({
+			articleId: articles.id,
+			title: articleTranslations.title,
+			content: articleTranslations.content,
+		})
+		.from(articles)
+		.innerJoin(
+			articleTranslations,
+			and(
+				eq(articleTranslations.articleId, articles.id),
+				eq(articleTranslations.language, "ja")
+			)
+		)
+		.where(eq(articles.status, "published"));
+
+	// 2. 既存 es を除外
+	const existingEs = await db
+		.select({ articleId: articleTranslations.articleId })
+		.from(articleTranslations)
+		.where(eq(articleTranslations.language, "es"));
+	const missing = applyLimit(
+		pickMissing(
+			jaRows,
+			existingEs.map((row) => row.articleId),
+			(row) => row.articleId
+		),
+		options.limit
+	);
+
+	console.log(
+		`📝 記事: es 未生成 ${missing.length} 件 / published ${jaRows.length} 件`
+	);
+
+	// 3. dry-run
+	if (options.dryRun) {
+		for (const row of missing) {
+			console.log(`   [dry-run] articleId=${row.articleId} "${row.title}"`);
+		}
+		return { target: missing.length, done: 0, skipped: 0 };
+	}
+
+	// 4-5. 翻訳して upsert
+	const translationService = createTranslationService({
+		GEMINI_API_KEY: apiKey,
+	});
+	let done = 0;
+	let skipped = 0;
+
+	for (const row of missing) {
+		const translated = await translationService.translateArticle(
+			row.title,
+			row.content,
+			"es"
+		);
+
+		if (!translated) {
+			console.warn(`   ⏭️  articleId=${row.articleId} 翻訳失敗のためスキップ`);
+			skipped += 1;
+			await sleep(RATE_LIMIT_DELAY_MS);
+			continue;
+		}
+
+		await db
+			.insert(articleTranslations)
+			.values({
+				articleId: row.articleId,
+				language: "es",
+				title: translated.title,
+				content: translated.content,
+			})
+			.onConflictDoUpdate({
+				target: [articleTranslations.articleId, articleTranslations.language],
+				set: { title: translated.title, content: translated.content },
+			});
+
+		console.log(`   ✅ articleId=${row.articleId} "${translated.title}"`);
+		done += 1;
+		await sleep(RATE_LIMIT_DELAY_MS);
+	}
+
+	return { target: missing.length, done, skipped };
+}
+
+// ---------------------------------------------------------------------------
+// ギャラリー画像（全件）
+// ---------------------------------------------------------------------------
+
+/**
+ * ギャラリー画像の es 翻訳をバックフィルする
+ *
+ * 処理フロー:
+ * 1. ja 翻訳を持つ画像のタイトル・説明を取得
+ * 2. 既存 es を除外
+ * 3. dry-run ならログのみ返す
+ * 4. タイトル・説明を Gemini で es に翻訳（translateWithGemini は失敗時 throw → try/catch）
+ * 5. (galleryImageId, language) をキーに upsert（冪等）
+ */
+async function backfillGalleryImages(
+	db: Db,
+	apiKey: string,
+	options: BackfillOptions
+): Promise<BackfillSummary> {
+	// 1. ja 翻訳を取得
+	const jaRows = await db
+		.select({
+			galleryImageId: galleryImages.id,
+			title: galleryImageTranslations.title,
+			description: galleryImageTranslations.description,
+		})
+		.from(galleryImages)
+		.innerJoin(
+			galleryImageTranslations,
+			and(
+				eq(galleryImageTranslations.galleryImageId, galleryImages.id),
+				eq(galleryImageTranslations.language, "ja")
+			)
+		);
+
+	// 2. 既存 es を除外
+	const existingEs = await db
+		.select({ galleryImageId: galleryImageTranslations.galleryImageId })
+		.from(galleryImageTranslations)
+		.where(eq(galleryImageTranslations.language, "es"));
+	const missing = applyLimit(
+		pickMissing(
+			jaRows,
+			existingEs.map((row) => row.galleryImageId),
+			(row) => row.galleryImageId
+		),
+		options.limit
+	);
+
+	console.log(
+		`🖼️  ギャラリー: es 未生成 ${missing.length} 件 / ja あり ${jaRows.length} 件`
+	);
+
+	// 3. dry-run
+	if (options.dryRun) {
+		for (const row of missing) {
+			console.log(
+				`   [dry-run] galleryImageId=${row.galleryImageId} "${row.title ?? ""}"`
+			);
+		}
+		return { target: missing.length, done: 0, skipped: 0 };
+	}
+
+	// 4-5. 翻訳して upsert
+	let done = 0;
+	let skipped = 0;
+
+	for (const row of missing) {
+		try {
+			// title / description は nullable。元が空なら翻訳せず null のままにする。
+			const titleEs = row.title
+				? await translateWithGemini(row.title, apiKey, "es")
+				: null;
+			const descriptionEs = row.description
+				? await translateWithGemini(row.description, apiKey, "es")
+				: null;
+
+			const now = new Date().toISOString();
+			await db
+				.insert(galleryImageTranslations)
+				.values({
+					galleryImageId: row.galleryImageId,
+					language: "es",
+					title: titleEs,
+					description: descriptionEs,
+					createdAt: now,
+					updatedAt: now,
+				})
+				.onConflictDoUpdate({
+					target: [
+						galleryImageTranslations.galleryImageId,
+						galleryImageTranslations.language,
+					],
+					set: { title: titleEs, description: descriptionEs, updatedAt: now },
+				});
+
+			console.log(
+				`   ✅ galleryImageId=${row.galleryImageId} "${titleEs ?? ""}"`
+			);
+			done += 1;
+		} catch (error) {
+			console.warn(
+				`   ⏭️  galleryImageId=${row.galleryImageId} 翻訳失敗のためスキップ:`,
+				error instanceof Error ? error.message : error
+			);
+			skipped += 1;
+		}
+		await sleep(RATE_LIMIT_DELAY_MS);
+	}
+
+	return { target: missing.length, done, skipped };
+}
+
+// ---------------------------------------------------------------------------
+// タグ（全件）
+// ---------------------------------------------------------------------------
+
+/**
+ * タグの es 翻訳をバックフィルする
+ *
+ * @remarks
+ * - tag_translations には (tagId, language) のユニーク制約が無いため upsert が使えない。
+ *   事前に既存 es の tagId を除外してから plain insert する。
+ * - 既存の translateTag は英語スラッグ生成専用プロンプトで表示ラベルに不適なため、
+ *   自然なスペイン語を得る translateWithGemini(..., "es") を使う。
+ *
+ * 処理フロー:
+ * 1. ja 翻訳を持つタグ名を取得
+ * 2. 既存 es を除外
+ * 3. dry-run ならログのみ返す
+ * 4. タグ名を Gemini で es に翻訳（失敗時 throw → try/catch）
+ * 5. es 行を挿入
+ */
+async function backfillTags(
+	db: Db,
+	apiKey: string,
+	options: BackfillOptions
+): Promise<BackfillSummary> {
+	// 1. ja 翻訳を取得
+	const jaRows = await db
+		.select({
+			tagId: tags.id,
+			name: tagTranslations.name,
+		})
+		.from(tags)
+		.innerJoin(
+			tagTranslations,
+			and(
+				eq(tagTranslations.tagId, tags.id),
+				eq(tagTranslations.language, "ja")
+			)
+		);
+
+	// 2. 既存 es を除外
+	const existingEs = await db
+		.select({ tagId: tagTranslations.tagId })
+		.from(tagTranslations)
+		.where(eq(tagTranslations.language, "es"));
+	const missing = applyLimit(
+		pickMissing(
+			jaRows,
+			existingEs.map((row) => row.tagId),
+			(row) => row.tagId
+		),
+		options.limit
+	);
+
+	console.log(
+		`🏷️  タグ: es 未生成 ${missing.length} 件 / ja あり ${jaRows.length} 件`
+	);
+
+	// 3. dry-run
+	if (options.dryRun) {
+		for (const row of missing) {
+			console.log(`   [dry-run] tagId=${row.tagId} "${row.name}"`);
+		}
+		return { target: missing.length, done: 0, skipped: 0 };
+	}
+
+	// 4-5. 翻訳して挿入
+	let done = 0;
+	let skipped = 0;
+
+	for (const row of missing) {
+		try {
+			const nameEs = await translateWithGemini(row.name, apiKey, "es");
+			await db.insert(tagTranslations).values({
+				tagId: row.tagId,
+				language: "es",
+				name: nameEs,
+			});
+			console.log(`   ✅ tagId=${row.tagId} "${row.name}" -> "${nameEs}"`);
+			done += 1;
+		} catch (error) {
+			console.warn(
+				`   ⏭️  tagId=${row.tagId} 翻訳失敗のためスキップ:`,
+				error instanceof Error ? error.message : error
+			);
+			skipped += 1;
+		}
+		await sleep(RATE_LIMIT_DELAY_MS);
+	}
+
+	return { target: missing.length, done, skipped };
+}
+
+// ---------------------------------------------------------------------------
+// エントリーポイント
+// ---------------------------------------------------------------------------
+
+/** コマンドライン引数を解釈する */
+function parseArgs(argv: string[]): BackfillOptions {
+	const dryRun = argv.includes("--dry-run");
+	const limitIndex = argv.indexOf("--limit");
+	const limit =
+		limitIndex !== -1
+			? Number.parseInt(argv[limitIndex + 1] ?? "", 10)
+			: undefined;
+	return {
+		dryRun,
+		limit: Number.isNaN(limit) ? undefined : limit,
+	};
+}
+
+async function main() {
+	// 環境変数をロード（apps/backend/.env）。本番 Turso はシェルの環境変数を優先。
+	const __dirname = path.dirname(fileURLToPath(import.meta.url));
+	dotenv.config({ path: path.resolve(__dirname, "../../.env") });
+
+	const apiKey = process.env.GEMINI_API_KEY;
+	const databaseUrl = process.env.TURSO_DATABASE_URL ?? "file:./local.db";
+	const authToken = process.env.TURSO_AUTH_TOKEN ?? "";
+
+	if (!apiKey) {
+		console.error(
+			"❌ GEMINI_API_KEY が未設定です。apps/backend/.env に設定するか、環境変数で渡してください。"
+		);
+		process.exit(1);
+	}
+
+	const options = parseArgs(process.argv.slice(2));
+	if (options.dryRun) {
+		console.log("🔍 dry-run モード: 書き込みは行いません");
+	}
+	if (options.limit !== undefined) {
+		console.log(`🔢 limit: 各種 ${options.limit} 件まで`);
+	}
+	console.log(`🗄️  DB: ${databaseUrl}`);
+
+	const db = createDatabaseClient({
+		TURSO_DATABASE_URL: databaseUrl,
+		TURSO_AUTH_TOKEN: authToken,
+	});
+
+	const articleSummary = await backfillArticles(db, apiKey, options);
+	const gallerySummary = await backfillGalleryImages(db, apiKey, options);
+	const tagSummary = await backfillTags(db, apiKey, options);
+
+	console.log("\n✅ バックフィル完了");
+	console.log(
+		`   記事:       対象 ${articleSummary.target} / 完了 ${articleSummary.done} / スキップ ${articleSummary.skipped}`
+	);
+	console.log(
+		`   ギャラリー: 対象 ${gallerySummary.target} / 完了 ${gallerySummary.done} / スキップ ${gallerySummary.skipped}`
+	);
+	console.log(
+		`   タグ:       対象 ${tagSummary.target} / 完了 ${tagSummary.done} / スキップ ${tagSummary.skipped}`
+	);
+
+	process.exit(0);
+}
+
+// このファイルを直接 tsx で実行したときだけ main を起動する。
+// テストから pickMissing を import しても main が走らないようにするため。
+const isDirectRun =
+	process.argv[1] !== undefined &&
+	import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectRun) {
+	main().catch((error) => {
+		console.error("❌ バックフィルに失敗しました", error);
+		process.exit(1);
+	});
+}

--- a/apps/backend/src/scripts/backfill-translations.test.ts
+++ b/apps/backend/src/scripts/backfill-translations.test.ts
@@ -1,19 +1,21 @@
 import { describe, expect, it } from "vitest";
 
-import { pickMissing } from "./backfill-es-translations";
+import { pickMissing } from "./backfill-translations";
 
 /**
  * pickMissing のテスト観点表（等価分割・境界値）
  *
- * | # | 観点                         | sources           | existingEsIds | 期待結果            |
- * |---|------------------------------|-------------------|---------------|---------------------|
- * | 1 | 一部に es あり（正常系）     | id 1,2,3          | [2]           | id 1,3              |
- * | 2 | es が全く無い                | id 1,2            | []            | id 1,2（全件）      |
- * | 3 | 全件に es あり               | id 1,2            | [1,2]         | []（空）            |
- * | 4 | sources が空                 | []                | [1]           | []（空）            |
- * | 5 | existingEsIds に重複         | id 1,2            | [1,1]         | id 2                |
- * | 6 | existingEsIds に無関係な ID  | id 1,2            | [99]          | id 1,2（全件）      |
- * | 7 | getId が別フィールドを参照   | galleryImageId    | [10]          | 該当以外            |
+ * existingTargetIds = 既に対象言語（en/es/ko…）の翻訳を持つ ID
+ *
+ * | # | 観点                          | sources        | existingTargetIds | 期待結果        |
+ * |---|-------------------------------|----------------|-------------------|-----------------|
+ * | 1 | 一部に対象言語あり（正常系）  | id 1,2,3       | [2]               | id 1,3          |
+ * | 2 | 対象言語が全く無い            | id 1,2         | []                | id 1,2（全件）  |
+ * | 3 | 全件に対象言語あり            | id 1,2         | [1,2]             | []（空）        |
+ * | 4 | sources が空                  | []             | [1]               | []（空）        |
+ * | 5 | existingTargetIds に重複      | id 1,2         | [1,1]             | id 2            |
+ * | 6 | existingTargetIds に無関係ID  | id 1,2         | [99]              | id 1,2（全件）  |
+ * | 7 | getId が別フィールドを参照    | galleryImageId | [10]              | 該当以外        |
  */
 
 type SourceRow = { articleId: number; title: string };

--- a/apps/backend/src/scripts/backfill-translations.ts
+++ b/apps/backend/src/scripts/backfill-translations.ts
@@ -1,30 +1,50 @@
 /**
- * 既存コンテンツにスペイン語（es）翻訳をバックフィルするスクリプト。
+ * 既存コンテンツの多言語翻訳をバックフィルするスクリプト。
  *
- * @description
- * サイトに es を追加したが、既存の記事・ギャラリー画像・タグには es 翻訳が無い。
- * `get-article` ハンドラは `language = lang` を厳密一致で引くため、es 行が無い記事は
- * `/es/blog/[slug]` で 404 になる。このスクリプトは既存の日本語（ja）コンテンツを走査し、
- * 欠けている es 翻訳を Gemini で生成して埋める。
+ * ============================================================================
+ * これは何をするもの？
+ * ============================================================================
+ * 記事・ギャラリー画像・タグは、新規作成/更新時にのみ日本語(ja)から他言語へ
+ * 自動翻訳される。そのため「後から対応言語を増やした」場合、既存コンテンツには
+ * その言語の翻訳が無い状態になる。
+ * 例: es を追加した直後は、既存記事に es 行が無いため /es/blog/[slug] が 404 になる。
+ *
+ * このスクリプトは既存の ja コンテンツを走査し、指定した言語（または全対応言語）の
+ * 「まだ翻訳が無い」ぶんだけを Gemini で生成して DB に埋める。
  *
  * 対象:
- * - 記事: status = "published" のみ（既存の en 自動翻訳の挙動に合わせる）
+ * - 記事: status = "published" のみ（新規作成時の自動翻訳が published 限定なのに合わせる）
  * - ギャラリー画像: ja 翻訳を持つ全件
- * - タグ: ja 翻訳を持つ全件（表示ラベル用途のため自然なスペイン語を生成する）
+ * - タグ: ja 翻訳を持つ全件（表示ラベル用途のため自然な訳語を生成する）
+ *
+ * 翻訳先の言語は TARGET_LANGUAGES（gemini-translation.ts）を単一ソースとする。
+ * 言語を1つ増やす手順は TARGET_LANGUAGES の定義コメントを参照。
+ *
+ * ============================================================================
+ * 使い方
+ * ============================================================================
+ *   # 全対応言語（TARGET_LANGUAGES）を対象に、書き込まず件数だけ確認
+ *   pnpm --filter @saneatsu/backend db:backfill -- --dry-run
+ *
+ *   # 特定言語だけを対象にする（例: 韓国語）。--dry-run と併用可
+ *   pnpm --filter @saneatsu/backend db:backfill -- --target ko --dry-run
+ *
+ *   # 動作確認用に各種の先頭 N 件だけ処理
+ *   pnpm --filter @saneatsu/backend db:backfill -- --target es --limit 3
+ *
+ *   # 本実行（フラグ無し = 全対応言語 × 全対象を翻訳・書き込み）
+ *   pnpm --filter @saneatsu/backend db:backfill
  *
  * 冪等性:
  * - 記事・ギャラリーは (id, language) のユニーク制約があるため onConflictDoUpdate で再実行安全。
- * - タグは (tagId, language) のユニーク制約が無いため、事前に既存 es を除外してから挿入する。
- *
- * 実行:
- * - `pnpm --filter @saneatsu/backend db:backfill-es`
- * - `... db:backfill-es -- --dry-run`   書き込まず対象件数のみ表示（本番前の確認用）
- * - `... db:backfill-es -- --limit 3`    各種の先頭3件だけ処理（動作確認用）
+ * - タグは (tagId, language) のユニーク制約が無いため、事前に既存訳を除外してから挿入する。
+ * - 途中で失敗しても再実行すれば「まだ無いぶん」だけ続きから埋まる。
  *
  * 環境変数（apps/backend/.env またはシェルの環境変数）:
  * - GEMINI_API_KEY       翻訳に使用
  * - TURSO_DATABASE_URL   ローカルは file:./local.db、本番は libsql://...
  * - TURSO_AUTH_TOKEN     本番 Turso のみ必要
+ * ============================================================================
  */
 
 import path from "node:path";
@@ -42,7 +62,12 @@ import dotenv from "dotenv";
 import { and, eq } from "drizzle-orm";
 
 import { translateWithGemini } from "../lib/translate";
-import { createTranslationService } from "../services/gemini-translation/gemini-translation";
+import {
+	createTranslationService,
+	type GeminiTranslationService,
+	TARGET_LANGUAGES,
+	type TargetLanguage,
+} from "../services/gemini-translation/gemini-translation";
 
 // ---------------------------------------------------------------------------
 // 型・ユーティリティ
@@ -61,7 +86,7 @@ type BackfillOptions = {
 
 /** 1種別ぶんの処理結果サマリー */
 type BackfillSummary = {
-	/** es が欠けていた（＝対象となった）件数 */
+	/** 翻訳が欠けていた（＝対象となった）件数 */
 	target: number;
 	/** 実際に翻訳・保存できた件数 */
 	done: number;
@@ -70,23 +95,23 @@ type BackfillSummary = {
 };
 
 /**
- * es が欠けているソース行だけを抽出する純粋関数
+ * 指定言語の翻訳が欠けているソース行だけを抽出する純粋関数
  *
  * @description
- * ja 翻訳を持つソース行のうち、既に es 翻訳を持つ ID を除外する。
+ * ja 翻訳を持つソース行のうち、既に対象言語の翻訳を持つ ID を除外する。
  * DB アクセスを含まないため単体テストしやすい。
  *
  * @param sources - ja 翻訳を持つソース行の配列
- * @param existingEsIds - 既に es 翻訳を持つ ID の配列
+ * @param existingTargetIds - 既に対象言語の翻訳を持つ ID の配列
  * @param getId - ソース行から対象 ID を取り出す関数
- * @returns es 翻訳がまだ無いソース行のみの配列
+ * @returns 対象言語の翻訳がまだ無いソース行のみの配列
  */
 export function pickMissing<T>(
 	sources: T[],
-	existingEsIds: number[],
+	existingTargetIds: number[],
 	getId: (source: T) => number
 ): T[] {
-	const existing = new Set(existingEsIds);
+	const existing = new Set(existingTargetIds);
 	return sources.filter((source) => !existing.has(getId(source)));
 }
 
@@ -108,18 +133,19 @@ function applyLimit<T>(items: T[], limit?: number): T[] {
 // ---------------------------------------------------------------------------
 
 /**
- * 公開記事の es 翻訳をバックフィルする
+ * 公開記事の翻訳を指定言語にバックフィルする
  *
  * 処理フロー:
  * 1. published 記事の ja タイトル・本文を取得
- * 2. 既に es 翻訳を持つ記事 ID を取得し、欠けているものだけに絞る
+ * 2. 既に対象言語の翻訳を持つ記事 ID を取得し、欠けているものだけに絞る
  * 3. dry-run ならログのみ返す
- * 4. 各記事を Gemini で es に翻訳（失敗時は null なのでスキップ）
+ * 4. 各記事を Gemini で対象言語に翻訳（失敗時は null なのでスキップ）
  * 5. (articleId, language) をキーに upsert（冪等）
  */
 async function backfillArticles(
 	db: Db,
-	apiKey: string,
+	translationService: GeminiTranslationService,
+	target: TargetLanguage,
 	options: BackfillOptions
 ): Promise<BackfillSummary> {
 	// 1. published 記事の ja 本文を取得
@@ -139,22 +165,22 @@ async function backfillArticles(
 		)
 		.where(eq(articles.status, "published"));
 
-	// 2. 既存 es を除外
-	const existingEs = await db
+	// 2. 既存の対象言語を除外
+	const existing = await db
 		.select({ articleId: articleTranslations.articleId })
 		.from(articleTranslations)
-		.where(eq(articleTranslations.language, "es"));
+		.where(eq(articleTranslations.language, target));
 	const missing = applyLimit(
 		pickMissing(
 			jaRows,
-			existingEs.map((row) => row.articleId),
+			existing.map((row) => row.articleId),
 			(row) => row.articleId
 		),
 		options.limit
 	);
 
 	console.log(
-		`📝 記事: es 未生成 ${missing.length} 件 / published ${jaRows.length} 件`
+		`📝 記事[${target}]: 未生成 ${missing.length} 件 / published ${jaRows.length} 件`
 	);
 
 	// 3. dry-run
@@ -166,9 +192,6 @@ async function backfillArticles(
 	}
 
 	// 4-5. 翻訳して upsert
-	const translationService = createTranslationService({
-		GEMINI_API_KEY: apiKey,
-	});
 	let done = 0;
 	let skipped = 0;
 
@@ -176,7 +199,7 @@ async function backfillArticles(
 		const translated = await translationService.translateArticle(
 			row.title,
 			row.content,
-			"es"
+			target
 		);
 
 		if (!translated) {
@@ -190,7 +213,7 @@ async function backfillArticles(
 			.insert(articleTranslations)
 			.values({
 				articleId: row.articleId,
-				language: "es",
+				language: target,
 				title: translated.title,
 				content: translated.content,
 			})
@@ -212,18 +235,19 @@ async function backfillArticles(
 // ---------------------------------------------------------------------------
 
 /**
- * ギャラリー画像の es 翻訳をバックフィルする
+ * ギャラリー画像の翻訳を指定言語にバックフィルする
  *
  * 処理フロー:
  * 1. ja 翻訳を持つ画像のタイトル・説明を取得
- * 2. 既存 es を除外
+ * 2. 既存の対象言語を除外
  * 3. dry-run ならログのみ返す
- * 4. タイトル・説明を Gemini で es に翻訳（translateWithGemini は失敗時 throw → try/catch）
+ * 4. タイトル・説明を Gemini で対象言語に翻訳（translateWithGemini は失敗時 throw → try/catch）
  * 5. (galleryImageId, language) をキーに upsert（冪等）
  */
 async function backfillGalleryImages(
 	db: Db,
 	apiKey: string,
+	target: TargetLanguage,
 	options: BackfillOptions
 ): Promise<BackfillSummary> {
 	// 1. ja 翻訳を取得
@@ -242,22 +266,22 @@ async function backfillGalleryImages(
 			)
 		);
 
-	// 2. 既存 es を除外
-	const existingEs = await db
+	// 2. 既存の対象言語を除外
+	const existing = await db
 		.select({ galleryImageId: galleryImageTranslations.galleryImageId })
 		.from(galleryImageTranslations)
-		.where(eq(galleryImageTranslations.language, "es"));
+		.where(eq(galleryImageTranslations.language, target));
 	const missing = applyLimit(
 		pickMissing(
 			jaRows,
-			existingEs.map((row) => row.galleryImageId),
+			existing.map((row) => row.galleryImageId),
 			(row) => row.galleryImageId
 		),
 		options.limit
 	);
 
 	console.log(
-		`🖼️  ギャラリー: es 未生成 ${missing.length} 件 / ja あり ${jaRows.length} 件`
+		`🖼️  ギャラリー[${target}]: 未生成 ${missing.length} 件 / ja あり ${jaRows.length} 件`
 	);
 
 	// 3. dry-run
@@ -277,11 +301,11 @@ async function backfillGalleryImages(
 	for (const row of missing) {
 		try {
 			// title / description は nullable。元が空なら翻訳せず null のままにする。
-			const titleEs = row.title
-				? await translateWithGemini(row.title, apiKey, "es")
+			const titleTranslated = row.title
+				? await translateWithGemini(row.title, apiKey, target)
 				: null;
-			const descriptionEs = row.description
-				? await translateWithGemini(row.description, apiKey, "es")
+			const descriptionTranslated = row.description
+				? await translateWithGemini(row.description, apiKey, target)
 				: null;
 
 			const now = new Date().toISOString();
@@ -289,9 +313,9 @@ async function backfillGalleryImages(
 				.insert(galleryImageTranslations)
 				.values({
 					galleryImageId: row.galleryImageId,
-					language: "es",
-					title: titleEs,
-					description: descriptionEs,
+					language: target,
+					title: titleTranslated,
+					description: descriptionTranslated,
 					createdAt: now,
 					updatedAt: now,
 				})
@@ -300,11 +324,15 @@ async function backfillGalleryImages(
 						galleryImageTranslations.galleryImageId,
 						galleryImageTranslations.language,
 					],
-					set: { title: titleEs, description: descriptionEs, updatedAt: now },
+					set: {
+						title: titleTranslated,
+						description: descriptionTranslated,
+						updatedAt: now,
+					},
 				});
 
 			console.log(
-				`   ✅ galleryImageId=${row.galleryImageId} "${titleEs ?? ""}"`
+				`   ✅ galleryImageId=${row.galleryImageId} "${titleTranslated ?? ""}"`
 			);
 			done += 1;
 		} catch (error) {
@@ -325,24 +353,25 @@ async function backfillGalleryImages(
 // ---------------------------------------------------------------------------
 
 /**
- * タグの es 翻訳をバックフィルする
+ * タグの翻訳を指定言語にバックフィルする
  *
  * @remarks
  * - tag_translations には (tagId, language) のユニーク制約が無いため upsert が使えない。
- *   事前に既存 es の tagId を除外してから plain insert する。
+ *   事前に既存の対象言語 tagId を除外してから plain insert する。
  * - 既存の translateTag は英語スラッグ生成専用プロンプトで表示ラベルに不適なため、
- *   自然なスペイン語を得る translateWithGemini(..., "es") を使う。
+ *   自然な訳語を得る translateWithGemini(..., target) を使う。
  *
  * 処理フロー:
  * 1. ja 翻訳を持つタグ名を取得
- * 2. 既存 es を除外
+ * 2. 既存の対象言語を除外
  * 3. dry-run ならログのみ返す
- * 4. タグ名を Gemini で es に翻訳（失敗時 throw → try/catch）
- * 5. es 行を挿入
+ * 4. タグ名を Gemini で対象言語に翻訳（失敗時 throw → try/catch）
+ * 5. 翻訳行を挿入
  */
 async function backfillTags(
 	db: Db,
 	apiKey: string,
+	target: TargetLanguage,
 	options: BackfillOptions
 ): Promise<BackfillSummary> {
 	// 1. ja 翻訳を取得
@@ -360,22 +389,22 @@ async function backfillTags(
 			)
 		);
 
-	// 2. 既存 es を除外
-	const existingEs = await db
+	// 2. 既存の対象言語を除外
+	const existing = await db
 		.select({ tagId: tagTranslations.tagId })
 		.from(tagTranslations)
-		.where(eq(tagTranslations.language, "es"));
+		.where(eq(tagTranslations.language, target));
 	const missing = applyLimit(
 		pickMissing(
 			jaRows,
-			existingEs.map((row) => row.tagId),
+			existing.map((row) => row.tagId),
 			(row) => row.tagId
 		),
 		options.limit
 	);
 
 	console.log(
-		`🏷️  タグ: es 未生成 ${missing.length} 件 / ja あり ${jaRows.length} 件`
+		`🏷️  タグ[${target}]: 未生成 ${missing.length} 件 / ja あり ${jaRows.length} 件`
 	);
 
 	// 3. dry-run
@@ -392,13 +421,19 @@ async function backfillTags(
 
 	for (const row of missing) {
 		try {
-			const nameEs = await translateWithGemini(row.name, apiKey, "es");
+			const nameTranslated = await translateWithGemini(
+				row.name,
+				apiKey,
+				target
+			);
 			await db.insert(tagTranslations).values({
 				tagId: row.tagId,
-				language: "es",
-				name: nameEs,
+				language: target,
+				name: nameTranslated,
 			});
-			console.log(`   ✅ tagId=${row.tagId} "${row.name}" -> "${nameEs}"`);
+			console.log(
+				`   ✅ tagId=${row.tagId} "${row.name}" -> "${nameTranslated}"`
+			);
 			done += 1;
 		} catch (error) {
 			console.warn(
@@ -417,24 +452,46 @@ async function backfillTags(
 // エントリーポイント
 // ---------------------------------------------------------------------------
 
-/** コマンドライン引数を解釈する */
-function parseArgs(argv: string[]): BackfillOptions {
+/** パース済みのコマンドライン引数 */
+type ParsedArgs = BackfillOptions & {
+	/** 翻訳先の言語（未指定なら全 TARGET_LANGUAGES を対象にする） */
+	targets: readonly TargetLanguage[];
+};
+
+/**
+ * コマンドライン引数を解釈する
+ *
+ * @throws --target に TARGET_LANGUAGES 外の値が渡された場合
+ */
+function parseArgs(argv: string[]): ParsedArgs {
 	const dryRun = argv.includes("--dry-run");
+
 	const limitIndex = argv.indexOf("--limit");
-	const limit =
+	const limitRaw =
 		limitIndex !== -1
 			? Number.parseInt(argv[limitIndex + 1] ?? "", 10)
-			: undefined;
-	return {
-		dryRun,
-		limit: Number.isNaN(limit) ? undefined : limit,
-	};
+			: Number.NaN;
+	const limit = Number.isNaN(limitRaw) ? undefined : limitRaw;
+
+	// --target を指定した場合はその言語のみ。未指定なら全対応言語。
+	const targetIndex = argv.indexOf("--target");
+	if (targetIndex === -1) {
+		return { dryRun, limit, targets: TARGET_LANGUAGES };
+	}
+
+	const requested = argv[targetIndex + 1];
+	if (!requested || !TARGET_LANGUAGES.includes(requested as TargetLanguage)) {
+		throw new Error(
+			`--target には次のいずれかを指定してください: ${TARGET_LANGUAGES.join(", ")}（指定値: ${requested ?? "なし"}）`
+		);
+	}
+	return { dryRun, limit, targets: [requested as TargetLanguage] };
 }
 
 async function main() {
 	// 環境変数をロード（apps/backend/.env）。本番 Turso はシェルの環境変数を優先。
-	const __dirname = path.dirname(fileURLToPath(import.meta.url));
-	dotenv.config({ path: path.resolve(__dirname, "../../.env") });
+	const currentDir = path.dirname(fileURLToPath(import.meta.url));
+	dotenv.config({ path: path.resolve(currentDir, "../../.env") });
 
 	const apiKey = process.env.GEMINI_API_KEY;
 	const databaseUrl = process.env.TURSO_DATABASE_URL ?? "file:./local.db";
@@ -447,35 +504,57 @@ async function main() {
 		process.exit(1);
 	}
 
-	const options = parseArgs(process.argv.slice(2));
+	let args: ParsedArgs;
+	try {
+		args = parseArgs(process.argv.slice(2));
+	} catch (error) {
+		console.error(`❌ ${error instanceof Error ? error.message : error}`);
+		process.exit(1);
+	}
+	const options: BackfillOptions = { dryRun: args.dryRun, limit: args.limit };
+
 	if (options.dryRun) {
 		console.log("🔍 dry-run モード: 書き込みは行いません");
 	}
 	if (options.limit !== undefined) {
 		console.log(`🔢 limit: 各種 ${options.limit} 件まで`);
 	}
+	console.log(`🌐 対象言語: ${args.targets.join(", ")}`);
 	console.log(`🗄️  DB: ${databaseUrl}`);
 
 	const db = createDatabaseClient({
 		TURSO_DATABASE_URL: databaseUrl,
 		TURSO_AUTH_TOKEN: authToken,
 	});
+	const translationService = createTranslationService({
+		GEMINI_API_KEY: apiKey,
+	});
 
-	const articleSummary = await backfillArticles(db, apiKey, options);
-	const gallerySummary = await backfillGalleryImages(db, apiKey, options);
-	const tagSummary = await backfillTags(db, apiKey, options);
+	// 対象言語ごとに、記事 → ギャラリー → タグ の順でバックフィルする
+	for (const target of args.targets) {
+		console.log(`\n──────── ${target} ────────`);
+		const articleSummary = await backfillArticles(
+			db,
+			translationService,
+			target,
+			options
+		);
+		const gallerySummary = await backfillGalleryImages(
+			db,
+			apiKey,
+			target,
+			options
+		);
+		const tagSummary = await backfillTags(db, apiKey, target, options);
+
+		console.log(
+			`   小計[${target}] 記事 ${articleSummary.done}/${articleSummary.target}, ` +
+				`ギャラリー ${gallerySummary.done}/${gallerySummary.target}, ` +
+				`タグ ${tagSummary.done}/${tagSummary.target}（完了/対象）`
+		);
+	}
 
 	console.log("\n✅ バックフィル完了");
-	console.log(
-		`   記事:       対象 ${articleSummary.target} / 完了 ${articleSummary.done} / スキップ ${articleSummary.skipped}`
-	);
-	console.log(
-		`   ギャラリー: 対象 ${gallerySummary.target} / 完了 ${gallerySummary.done} / スキップ ${gallerySummary.skipped}`
-	);
-	console.log(
-		`   タグ:       対象 ${tagSummary.target} / 完了 ${tagSummary.done} / スキップ ${tagSummary.skipped}`
-	);
-
 	process.exit(0);
 }
 

--- a/apps/backend/src/services/gemini-translation/gemini-translation.ts
+++ b/apps/backend/src/services/gemini-translation/gemini-translation.ts
@@ -2,11 +2,34 @@ import type { GenerativeModel } from "@google/generative-ai";
 import { GoogleGenerativeAI } from "@google/generative-ai";
 
 /**
+ * 翻訳先の言語コード
+ *
+ * @description
+ * 翻訳元は常に日本語（ja）なので、翻訳先の言語のみを型で表現する。
+ * サイトのサポート言語（@saneatsu/i18n の locales）から日本語を除いたもの。
+ */
+export type TargetLanguage = "en" | "es";
+
+/**
+ * 翻訳先言語コードと、プロンプトで使う言語名の対応表
+ *
+ * @description
+ * Gemini へのプロンプトは英語ではなく「自然な◯◯語に翻訳して」と
+ * 言語名で指示するため、コードから表示名への変換表を持つ。
+ */
+const TARGET_LANGUAGE_NAMES: Record<TargetLanguage, string> = {
+	en: "英語",
+	es: "スペイン語",
+};
+
+/**
  * Gemini APIを使った翻訳サービス
  *
  * @description
- * - 記事（タイトル・本文）の翻訳: Markdown形式を保持した日英翻訳
- * - タグ名の翻訳: 適切な英語表現への変換
+ * - 記事（タイトル・本文）の翻訳: Markdown形式を保持した日本語→多言語翻訳
+ * - タグ名の翻訳: 適切な英語（スラッグ用）表現への変換
+ *
+ * 翻訳元は常に日本語で、翻訳先は `TargetLanguage`（英語・スペイン語など）を指定する。
  */
 export class GeminiTranslationService {
 	private genAI: GoogleGenerativeAI;
@@ -22,18 +45,24 @@ export class GeminiTranslationService {
 	 * 記事の翻訳プロンプトを生成
 	 * @param title - 記事のタイトル
 	 * @param content - 記事の本文（Markdown形式）
+	 * @param targetLanguage - 翻訳先の言語コード
 	 * @returns 翻訳用プロンプト
 	 */
-	private createTranslationPrompt(title: string, content: string): string {
-		return `以下の日本語の記事を英語に翻訳してください。
+	private createTranslationPrompt(
+		title: string,
+		content: string,
+		targetLanguage: TargetLanguage
+	): string {
+		const languageName = TARGET_LANGUAGE_NAMES[targetLanguage];
+		return `以下の日本語の記事を${languageName}に翻訳してください。
 
 重要な条件：
 1. Markdown記法を完全に保持してください（見出し、リスト、リンク、コードブロック、表など）
 2. [[記事名]] のようなWikiLink記法はそのまま保持してください
 3. コードブロック内のコードは翻訳しないでください
 4. URLやファイルパスは変更しないでください
-5. 自然で読みやすい英語にしてください
-6. 専門用語は適切な英語表現を使用してください
+5. 自然で読みやすい${languageName}にしてください
+6. 専門用語は適切な${languageName}表現を使用してください
 
 翻訳する記事：
 タイトル: ${title}
@@ -48,18 +77,24 @@ CONTENT:
 	}
 
 	/**
-	 * 記事を日本語から英語に翻訳
+	 * 記事を日本語から指定言語に翻訳
 	 * @param title - 日本語のタイトル
 	 * @param content - 日本語の本文
+	 * @param targetLanguage - 翻訳先の言語コード（省略時は英語）
 	 * @returns 翻訳結果（タイトルと本文）
 	 */
 	async translateArticle(
 		title: string,
-		content: string
+		content: string,
+		targetLanguage: TargetLanguage = "en"
 	): Promise<{ title: string; content: string } | null> {
 		try {
 			// 翻訳プロンプトを生成
-			const prompt = this.createTranslationPrompt(title, content);
+			const prompt = this.createTranslationPrompt(
+				title,
+				content,
+				targetLanguage
+			);
 
 			// Gemini APIを呼び出し
 			const result = await this.model.generateContent(prompt);

--- a/apps/backend/src/services/gemini-translation/gemini-translation.ts
+++ b/apps/backend/src/services/gemini-translation/gemini-translation.ts
@@ -2,22 +2,32 @@ import type { GenerativeModel } from "@google/generative-ai";
 import { GoogleGenerativeAI } from "@google/generative-ai";
 
 /**
- * 翻訳先の言語コード
+ * 自動翻訳の対応言語（＝翻訳先ロケール）の一覧
  *
  * @description
- * 翻訳元は常に日本語（ja）なので、翻訳先の言語のみを型で表現する。
- * サイトのサポート言語（@saneatsu/i18n の locales）から日本語を除いたもの。
+ * サイトが「Geminiで翻訳できる言語」の単一のソース・オブ・トゥルース。
+ * 翻訳元は常に日本語（ja）なのでここには含めない。
+ * 記事・ギャラリー・タグの自動翻訳、およびバックフィルスクリプトは
+ * すべてこの配列を参照するため、言語を1つ増やす手順はこうなる:
+ *   1. この配列に locale を追加する（例: "ko"）
+ *   2. TARGET_LANGUAGE_NAMES / SYSTEM_INSTRUCTION_BY_LANGUAGE は
+ *      Record<TargetLanguage> なので、追記漏れを TypeScript がエラーで教えてくれる
+ *   3. 併せて i18n の locales・DB の language enum・UI の <locale>.json も追加する
  */
-export type TargetLanguage = "en" | "es";
+export const TARGET_LANGUAGES = ["en", "es"] as const;
+
+/** 翻訳先の言語コード（TARGET_LANGUAGES から導出） */
+export type TargetLanguage = (typeof TARGET_LANGUAGES)[number];
 
 /**
- * 翻訳先言語コードと、プロンプトで使う言語名の対応表
+ * 翻訳先言語コードと、プロンプトで使う言語名（日本語）の対応表
  *
  * @description
- * Gemini へのプロンプトは英語ではなく「自然な◯◯語に翻訳して」と
- * 言語名で指示するため、コードから表示名への変換表を持つ。
+ * Gemini へのプロンプトは「自然な◯◯語に翻訳して」と言語名で指示するため、
+ * コードから表示名への変換表を持つ。警告メッセージのラベルにも再利用する。
+ * TARGET_LANGUAGES に言語を足すと、この Record が不足しビルドエラーになる。
  */
-const TARGET_LANGUAGE_NAMES: Record<TargetLanguage, string> = {
+export const TARGET_LANGUAGE_NAMES: Record<TargetLanguage, string> = {
 	en: "英語",
 	es: "スペイン語",
 };

--- a/apps/backend/src/utils/wiki-link/wiki-link.ts
+++ b/apps/backend/src/utils/wiki-link/wiki-link.ts
@@ -55,7 +55,7 @@ export function extractWikiLinks(content: string): string[] {
 export async function fetchArticleInfoBySlugs(
 	db: DrizzleClient,
 	slugs: string[],
-	language: "ja" | "en"
+	language: "ja" | "en" | "es"
 ): Promise<Map<string, WikiLinkInfo>> {
 	if (slugs.length === 0) {
 		return new Map();
@@ -119,7 +119,7 @@ export async function fetchArticleInfoBySlugs(
 export async function convertWikiLinks(
 	db: DrizzleClient,
 	content: string,
-	language: "ja" | "en"
+	language: "ja" | "en" | "es"
 ): Promise<string> {
 	// Wiki Linkを抽出
 	const slugs = extractWikiLinks(content);

--- a/apps/docs/docs/deployment/i18n-translations.md
+++ b/apps/docs/docs/deployment/i18n-translations.md
@@ -1,0 +1,117 @@
+---
+sidebar_position: 4
+---
+
+# 多言語翻訳とデプロイ (i18n)
+
+多言語対応（記事・ギャラリー・タグ・UI文言）を staging / production へ反映する手順と、
+新しい言語を追加するときのチェックリストをまとめます。
+
+## 翻訳の2系統
+
+翻訳対象は大きく2つに分かれます。
+
+| 系統 | 対象 | 保存場所 | 翻訳手段 |
+|---|---|---|---|
+| **静的UI文言** | ボタン・ラベル・バリデーション等 | `packages/i18n/src/locales/<locale>.json` | 手動で翻訳ファイルを用意 |
+| **動的コンテンツ** | 記事・ギャラリー画像・タグ | DB の `*_translations` テーブル | 日本語(ja)を原文に Gemini で自動翻訳 |
+
+翻訳先の言語は `apps/backend/src/services/gemini-translation/gemini-translation.ts` の
+`TARGET_LANGUAGES` を単一のソース・オブ・トゥルースとしています。
+
+## 新規コンテンツと既存コンテンツの違い（重要）
+
+動的コンテンツの翻訳は、**新規・既存で反映方法が異なります**。
+
+- **新規/更新コンテンツ**: 記事の作成・更新（published のみ）、ギャラリー画像のアップロード時に、
+  `TARGET_LANGUAGES` の全言語へ自動翻訳されて DB に保存されます。デプロイ後は自動で反映されます。
+- **既存コンテンツ**: 後から言語を追加した場合、既存レコードにはその言語の翻訳行がありません。
+  **自動では入らない**ため、後述のバックフィルスクリプトを手動実行する必要があります。
+  これを行わないと、例えば `/es/blog/[slug]` が 404 になります
+  （`get-article` は `language = lang` を厳密一致で引くため）。
+
+## デプロイフロー（コードは自動反映）
+
+コードの反映は GitHub Actions で自動化されています
+（`.github/workflows/deploy-backend.yml` / `deploy-web.yml`）。
+
+| 操作 | 反映先 | 仕組み |
+|---|---|---|
+| PR を開く（draft 以外） | **staging = preview 環境** | `pull_request` トリガーで自動デプロイ |
+| main へマージ（= main への push） | **production** | `push: branches: [main]` で自動デプロイ |
+| 手動実行 | 任意 | 各ワークフローの `workflow_dispatch` |
+
+対象パスは `apps/backend/**`・`apps/frontend/**`・`packages/**` です。
+
+### DB スキーマ変更（enum への言語追加）はマイグレーション不要
+
+`*_translations` テーブルの `language` enum に言語を足すと `migrate-database.yml` が
+トリガーされますが、実処理の `drizzle-kit db:push` は SQLite の text enum に CHECK 制約を
+張らないため**実質 no-op**です。新しい SQL マイグレーションファイルも不要で、DB 構造の変更は起きません。
+
+## バックフィルの実行（唯一の手動ステップ）
+
+既存コンテンツの翻訳を埋めるスクリプトが `apps/backend/src/scripts/backfill-translations.ts` です。
+コマンドは `db:backfill` で登録されています。
+
+:::caution
+preview と production は**別々の Turso DB**（`TURSO_DATABASE_URL_PREVIEW` / `_PROD`）です。
+翻訳を反映したい環境の認証情報を指定して、それぞれ実行してください。
+:::
+
+```bash
+# 対象環境の Turso 認証情報を環境変数で渡す（apps/backend/.env に入れてもよい）
+export TURSO_DATABASE_URL="libsql://<対象環境>.turso.io"
+export TURSO_AUTH_TOKEN="<対象環境のトークン>"
+
+# 1. まず件数だけ確認（書き込みなし）
+pnpm --filter @saneatsu/backend db:backfill -- --dry-run
+
+# 2. 問題なければ本実行（フラグ無し = 全対応言語 × 全対象）
+pnpm --filter @saneatsu/backend db:backfill
+```
+
+その他のフラグ:
+
+```bash
+# 特定言語だけを対象にする（例: 韓国語）
+pnpm --filter @saneatsu/backend db:backfill -- --target ko
+
+# 動作確認用に各種の先頭 N 件だけ処理
+pnpm --filter @saneatsu/backend db:backfill -- --target es --limit 3
+```
+
+対象と特性:
+
+- **記事**: `status = "published"` のみ（新規作成時の自動翻訳が published 限定なのに合わせる）
+- **ギャラリー画像**: ja 翻訳を持つ全件
+- **タグ**: ja 翻訳を持つ全件（表示ラベル用途のため自然な訳語を生成）
+- **冪等**: 記事・ギャラリーは `(id, language)` の upsert、タグは既存訳を除外してから挿入。
+  途中で失敗しても再実行すれば「まだ無いぶん」だけ続きから埋まります。
+- **レート制限**: Gemini 呼び出し間に約 1 秒の待機を入れています。
+
+## 新しい言語を追加するときのチェックリスト
+
+例として韓国語 `ko` を追加する場合の手順です。①〜④のコード変更を終えれば、
+新規コンテンツの自動翻訳とバックフィルは `ko` を自動で処理します
+（ハンドラ・バックフィルスクリプトは無改修）。
+
+1. **i18n 設定** — `packages/i18n/src/config.ts`
+   - `locales` に `"ko"` を追加
+   - `bcp47ByLocale`（`ko-KR`）と `openGraphLocaleByLocale`（`ko_KR`）に 1 行ずつ追加
+2. **UI 文言** — `packages/i18n/src/locales/ko.json` を新規作成（`en.json` と同じキー構成で全キー翻訳）
+3. **DB enum** — 3 テーブルの `language` enum に `"ko"` を追加
+   - `packages/db/src/schema/article_translations.ts`
+   - `packages/db/src/schema/gallery-image-translations.ts`
+   - `packages/db/src/schema/tag_translations.ts`
+4. **翻訳サービス** — `apps/backend/src/services/gemini-translation/gemini-translation.ts`
+   - `TARGET_LANGUAGES` に `"ko"` を追加
+   - `TARGET_LANGUAGE_NAMES` と `translate-with-gemini.ts` の `SYSTEM_INSTRUCTION_BY_LANGUAGE` は
+     `Record<TargetLanguage>` なので、追記漏れは TypeScript がビルドエラーで教えてくれる
+5. **デプロイ** — PR を開いて preview 反映を確認 → main マージで production 反映
+6. **バックフィル** — preview / production の各 Turso に対して `db:backfill --target ko` を実行
+
+:::tip
+`①③④` は「翻訳できる言語」の定義、`②` は UI 文言、`⑥` は既存コンテンツの反映です。
+`⑤` のコードデプロイは自動ですが、`⑥` のバックフィルだけは環境ごとに手動で実行します。
+:::

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -72,6 +72,7 @@ const sidebars: SidebarsConfig = {
 				"deployment/ci-cd",
 				"deployment/environment-variables",
 				"deployment/cloudflare-images",
+				"deployment/i18n-translations",
 			],
 		},
 		// Additional docs will be added as we create them

--- a/apps/frontend/src/app/[locale]/blog/[slug]/opengraph-image.tsx
+++ b/apps/frontend/src/app/[locale]/blog/[slug]/opengraph-image.tsx
@@ -39,7 +39,7 @@ export default async function Image({ params }: OgImageProps) {
 	try {
 		// 記事データを取得
 		const articleResponse = await fetchArticle(slug, {
-			lang: locale as "ja" | "en",
+			lang: locale as "ja" | "en" | "es",
 		});
 		const article = articleResponse.data;
 

--- a/apps/frontend/src/app/[locale]/blog/[slug]/page.tsx
+++ b/apps/frontend/src/app/[locale]/blog/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { openGraphLocaleByLocale } from "@saneatsu/i18n";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
 
@@ -33,7 +34,7 @@ export async function generateMetadata({
 	try {
 		// 記事データを取得
 		const articleResponse = await fetchArticle(slug, {
-			lang: locale as "ja" | "en",
+			lang: locale as "ja" | "en" | "es",
 		});
 		const article = articleResponse.data;
 
@@ -72,7 +73,7 @@ export async function generateMetadata({
 						alt: article.title,
 					},
 				],
-				locale: locale === "ja" ? "ja_JP" : "en_US",
+				locale: openGraphLocaleByLocale[locale as "ja" | "en" | "es"],
 			},
 			twitter: {
 				card: "summary_large_image",
@@ -118,7 +119,7 @@ export async function generateMetadata({
 						alt: "saneatsu.me",
 					},
 				],
-				locale: locale === "ja" ? "ja_JP" : "en_US",
+				locale: openGraphLocaleByLocale[locale as "ja" | "en" | "es"],
 			},
 			twitter: {
 				card: "summary_large_image",

--- a/apps/frontend/src/app/[locale]/layout.tsx
+++ b/apps/frontend/src/app/[locale]/layout.tsx
@@ -1,3 +1,5 @@
+import type { Locale } from "@saneatsu/i18n";
+import { locales } from "@saneatsu/i18n";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { NextIntlClientProvider } from "next-intl";
@@ -8,10 +10,6 @@ import { Header } from "@/widgets/header";
 import { MobileMenu } from "@/widgets/mobile-menu";
 
 import { LayoutShell } from "./layout-shell";
-
-// サポートされているロケール
-const locales = ["ja", "en"] as const;
-type Locale = (typeof locales)[number];
 
 function isValidLocale(locale: string): locale is Locale {
 	return locales.includes(locale as Locale);
@@ -44,20 +42,29 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 			description:
 				"Articles about programming, development tools, and daily insights on technology and lifestyle.",
 		},
+		es: {
+			title: "saneatsu.me",
+			description:
+				"Artículos sobre programación, herramientas de desarrollo y reflexiones cotidianas sobre tecnología y estilo de vida.",
+		},
 	};
 
 	const currentMetadata = isValidLocale(locale)
 		? metadata[locale]
-		: metadata.ja;
+		: metadata.en;
 
 	return {
 		title: currentMetadata.title,
 		description: currentMetadata.description,
 		alternates: {
-			languages: {
-				ja: "/ja",
-				en: "/en",
-			},
+			// hreflang: 各言語バージョンの存在を検索エンジンに伝える。
+			// locales に追加した言語は自動的にすべて対象になる。
+			languages: Object.fromEntries(
+				locales.map((supportedLocale) => [
+					supportedLocale,
+					`/${supportedLocale}`,
+				])
+			),
 		},
 	};
 }

--- a/apps/frontend/src/app/[locale]/rss.xml/route.ts
+++ b/apps/frontend/src/app/[locale]/rss.xml/route.ts
@@ -1,15 +1,12 @@
+import type { Locale } from "@saneatsu/i18n";
+import { bcp47ByLocale, locales as SUPPORTED_LOCALES } from "@saneatsu/i18n";
 import { NextResponse } from "next/server";
 
 import { extractDescription, fetchArticles } from "@/shared/lib";
 import type { ArticlesResponse } from "@/shared/model";
 
-const SUPPORTED_LOCALES = ["ja", "en"] as const;
-type Locale = (typeof SUPPORTED_LOCALES)[number];
-
-const LOCALE_LANGUAGE_MAP: Record<Locale, string> = {
-	ja: "ja-JP",
-	en: "en-US",
-};
+// BCP 47 言語タグはロケール設定の単一ソースから取得する
+const LOCALE_LANGUAGE_MAP = bcp47ByLocale;
 
 const FEED_METADATA: Record<Locale, { title: string; description: string }> = {
 	ja: {
@@ -21,6 +18,11 @@ const FEED_METADATA: Record<Locale, { title: string; description: string }> = {
 		title: "saneatsu.me (English)",
 		description:
 			"Articles about programming, development tools, and daily insights on technology and lifestyle.",
+	},
+	es: {
+		title: "saneatsu.me (Español)",
+		description:
+			"Artículos sobre programación, herramientas de desarrollo y reflexiones cotidianas sobre tecnología y estilo de vida.",
 	},
 };
 

--- a/apps/frontend/src/entities/article/api/use-get-all/use-get-all.ts
+++ b/apps/frontend/src/entities/article/api/use-get-all/use-get-all.ts
@@ -15,7 +15,7 @@ type UseGetAllArticlesOptions = {
 	/** 1ページあたりの記事数 */
 	limit?: number;
 	/** 言語 */
-	language?: "ja" | "en";
+	language?: "ja" | "en" | "es";
 	/** 記事のステータス（複数選択可能） */
 	status?: ArticleStatus[];
 	/** タグID（複数選択可能） */

--- a/apps/frontend/src/entities/article/api/use-get-article-by-slug/use-get-article-by-slug.ts
+++ b/apps/frontend/src/entities/article/api/use-get-article-by-slug/use-get-article-by-slug.ts
@@ -13,7 +13,7 @@ export type UseGetArticleBySlugOptions = {
 	/** 記事のスラッグ */
 	slug: string;
 	/** 言語 */
-	language?: "ja" | "en";
+	language?: "ja" | "en" | "es";
 	/** React Queryの設定 */
 	queryConfig?: QueryConfig<() => Promise<ArticleResponse>>;
 };

--- a/apps/frontend/src/entities/article/api/use-get-by-id/use-get-by-id.ts
+++ b/apps/frontend/src/entities/article/api/use-get-by-id/use-get-by-id.ts
@@ -52,7 +52,7 @@ type ArticleWithTags = {
 export const useGetById = (
 	id: number,
 	options?: {
-		language?: "ja" | "en";
+		language?: "ja" | "en" | "es";
 		includeAllTranslations?: boolean;
 		enabled?: boolean;
 		onSuccess?: (data: ArticleWithTags) => void;

--- a/apps/frontend/src/entities/article/api/use-get-related/use-get-related.ts
+++ b/apps/frontend/src/entities/article/api/use-get-related/use-get-related.ts
@@ -13,7 +13,7 @@ type UseGetRelatedOptions = {
 	/** 記事のスラッグ */
 	slug: string;
 	/** 言語 */
-	lang?: "ja" | "en";
+	lang?: "ja" | "en" | "es";
 	/** 取得する記事数 */
 	limit?: number;
 	/** React Queryの設定 */

--- a/apps/frontend/src/entities/article/api/use-suggestions/use-suggestions.ts
+++ b/apps/frontend/src/entities/article/api/use-suggestions/use-suggestions.ts
@@ -45,7 +45,7 @@ type UseArticleSuggestionsOptions = {
 	/** 検索クエリ */
 	query: string;
 	/** 言語 */
-	language?: "ja" | "en";
+	language?: "ja" | "en" | "es";
 	/** 最大件数 */
 	limit?: number;
 	/** 特定記事の見出しのみを取得したい場合の記事スラッグ */
@@ -103,7 +103,7 @@ export function useArticleSuggestions({
 		queryFn: async () => {
 			const queryParams: {
 				q: string;
-				lang: "ja" | "en";
+				lang: "ja" | "en" | "es";
 				limit: string;
 				targetSlug?: string;
 			} = {

--- a/apps/frontend/src/entities/article/ui/article-card/article-card.tsx
+++ b/apps/frontend/src/entities/article/ui/article-card/article-card.tsx
@@ -21,7 +21,7 @@ export function ArticleCard({ article }: ArticleCardProps) {
 	// 更新日の相対日付フォーマット
 	const updatedDateInfo = formatRelativeDate(
 		article.updatedAt ?? null,
-		locale as "ja" | "en"
+		locale as "ja" | "en" | "es"
 	);
 
 	// コンテンツから本文の抜粋を生成

--- a/apps/frontend/src/entities/article/ui/article-suggestions-popover/article-suggestions-popover.tsx
+++ b/apps/frontend/src/entities/article/ui/article-suggestions-popover/article-suggestions-popover.tsx
@@ -28,7 +28,7 @@ export interface ArticleSuggestionsPopoverProps {
 	/** 検索クエリ */
 	query: string;
 	/** 言語設定 */
-	language?: "ja" | "en";
+	language?: "ja" | "en" | "es";
 	/** サジェストが選択された時のコールバック */
 	onSelect: (suggestion: SuggestionItem) => void;
 	/** カーソル位置（ポップアップの表示位置用） */

--- a/apps/frontend/src/entities/article/ui/wiki-link/wiki-link.tsx
+++ b/apps/frontend/src/entities/article/ui/wiki-link/wiki-link.tsx
@@ -12,7 +12,7 @@ export interface WikiLinkProps extends ComponentPropsWithoutRef<"a"> {
 	/** リンク先のURL */
 	href: string;
 	/** 言語設定 */
-	language?: "ja" | "en";
+	language?: "ja" | "en" | "es";
 	/** デフォルトの表示テキスト（タイトル取得中の表示用） */
 	children: React.ReactNode;
 }

--- a/apps/frontend/src/entities/gallery/api/use-get-gallery-image-by-id/use-get-gallery-image-by-id.ts
+++ b/apps/frontend/src/entities/gallery/api/use-get-gallery-image-by-id/use-get-gallery-image-by-id.ts
@@ -14,7 +14,7 @@ type UseGetGalleryImageByIdOptions = {
 	/** 画像ID */
 	id: number;
 	/** 言語 */
-	language?: "ja" | "en";
+	language?: "ja" | "en" | "es";
 	/** React Queryの設定 */
 	queryConfig?: QueryConfig<() => Promise<GalleryImage>>;
 };

--- a/apps/frontend/src/entities/gallery/model/types.ts
+++ b/apps/frontend/src/entities/gallery/model/types.ts
@@ -9,7 +9,7 @@ export type GalleryImageTranslation = {
 	/** ギャラリー画像ID */
 	galleryImageId: number;
 	/** 言語コード */
-	language: "ja" | "en";
+	language: "ja" | "en" | "es";
 	/** 画像タイトル */
 	title: string | null;
 	/** 画像の説明 */
@@ -95,7 +95,7 @@ export type GalleryImageUploadResponse = {
  */
 export type GalleryImageUpdateTranslation = {
 	/** 言語コード */
-	language: "ja" | "en";
+	language: "ja" | "en" | "es";
 	/** タイトル（オプショナル） */
 	title?: string;
 	/** 説明（オプショナル） */
@@ -205,7 +205,7 @@ export type GeocodingSearchParams = {
 	/** 検索クエリ（住所、地名など） */
 	q: string;
 	/** 言語コード */
-	language?: "ja" | "en";
+	language?: "ja" | "en" | "es";
 	/** 結果の最大数 */
 	limit?: number;
 };

--- a/apps/frontend/src/entities/gallery/ui/address-search/address-search.tsx
+++ b/apps/frontend/src/entities/gallery/ui/address-search/address-search.tsx
@@ -12,7 +12,7 @@ export interface AddressSearchProps {
 	/** 住所選択時のコールバック */
 	onSelect: (coordinates: Coordinates, address: string) => void;
 	/** 検索言語（デフォルト: ja）*/
-	language?: "ja" | "en";
+	language?: "ja" | "en" | "es";
 	/** 検索結果の最大数（デフォルト: 5）*/
 	limit?: number;
 	/** プレースホルダーテキスト */

--- a/apps/frontend/src/entities/tag/ui/tag-badge/tag-badge.tsx
+++ b/apps/frontend/src/entities/tag/ui/tag-badge/tag-badge.tsx
@@ -28,7 +28,7 @@ export interface TagBadgeProps {
  * ```
  */
 export function TagBadge({ tag, className }: TagBadgeProps) {
-	const locale = useLocale() as "ja" | "en";
+	const locale = useLocale() as "ja" | "en" | "es";
 
 	// ロケールに応じたタグ名を取得、なければslugをフォールバック
 	const tagName = tag.translations[locale] || tag.slug;

--- a/apps/frontend/src/features/article-editor/ui/custom-markdown-editor/custom-markdown-editor.tsx
+++ b/apps/frontend/src/features/article-editor/ui/custom-markdown-editor/custom-markdown-editor.tsx
@@ -46,7 +46,7 @@ interface CustomMarkdownEditorProps {
 	/** 追加のCSSクラス */
 	className?: string;
 	/** 言語（Wiki Link用） */
-	language?: "ja" | "en";
+	language?: "ja" | "en" | "es";
 	/** 英語コンテンツ（プレビュー表示用） */
 	enContent?: string;
 	/** タグ検知時のコールバック */

--- a/apps/frontend/src/features/article-management/model/columns.tsx
+++ b/apps/frontend/src/features/article-management/model/columns.tsx
@@ -45,7 +45,7 @@ function DateCell({ dateString }: { dateString: string | null }) {
 
 	if (!dateString) return <span className="text-muted-foreground">未設定</span>;
 
-	const dateInfo = formatRelativeDate(dateString, locale as "ja" | "en");
+	const dateInfo = formatRelativeDate(dateString, locale as "ja" | "en" | "es");
 
 	if (!dateInfo)
 		return <span className="text-muted-foreground">無効な日付</span>;

--- a/apps/frontend/src/features/article-management/ui/article-edit-form/article-edit-form.tsx
+++ b/apps/frontend/src/features/article-management/ui/article-edit-form/article-edit-form.tsx
@@ -137,10 +137,12 @@ export function ArticleEditForm({ article }: ArticleEditFormProps) {
 	const enContent = article.translations?.en.content || "";
 
 	// タイトルの表示言語
-	const [titleLanguage, setTitleLanguage] = useState<"ja" | "en">("ja");
+	const [titleLanguage, setTitleLanguage] = useState<"ja" | "en" | "es">("ja");
 
 	// プレビューの表示言語
-	const [previewLanguage, setPreviewLanguage] = useState<"ja" | "en">("ja");
+	const [previewLanguage, setPreviewLanguage] = useState<"ja" | "en" | "es">(
+		"ja"
+	);
 
 	/**
 	 * サムネイルURLを生成
@@ -446,7 +448,7 @@ export function ArticleEditForm({ article }: ArticleEditFormProps) {
 									<Tabs
 										value={titleLanguage}
 										onValueChange={(value) =>
-											setTitleLanguage(value as "ja" | "en")
+											setTitleLanguage(value as "ja" | "en" | "es")
 										}
 									>
 										<TabsList className="h-8">
@@ -601,7 +603,7 @@ export function ArticleEditForm({ article }: ArticleEditFormProps) {
 							<Tabs
 								value={previewLanguage}
 								onValueChange={(value) =>
-									setPreviewLanguage(value as "ja" | "en")
+									setPreviewLanguage(value as "ja" | "en" | "es")
 								}
 							>
 								<TabsList className="h-8">

--- a/apps/frontend/src/features/article-management/ui/related-articles/related-articles.tsx
+++ b/apps/frontend/src/features/article-management/ui/related-articles/related-articles.tsx
@@ -26,7 +26,7 @@ export function RelatedArticles({ slug, limit = 10 }: RelatedArticlesProps) {
 
 	const { data, isLoading, error } = useGetRelated({
 		slug,
-		lang: locale as "ja" | "en",
+		lang: locale as "ja" | "en" | "es",
 		limit,
 	});
 

--- a/apps/frontend/src/features/contributions/api/use-dashboard-contributions/use-dashboard-contributions.ts
+++ b/apps/frontend/src/features/contributions/api/use-dashboard-contributions/use-dashboard-contributions.ts
@@ -7,7 +7,7 @@ import type { QueryConfig } from "@/shared/lib";
 import type { DashboardOverviewResponseData } from "@/shared/model";
 
 type UseDashboardContributionsOptions = {
-	language?: "ja" | "en";
+	language?: "ja" | "en" | "es";
 	queryConfig?: QueryConfig<() => Promise<DashboardOverviewResponseData>>;
 };
 

--- a/apps/frontend/src/features/contributions/api/use-public-contributions/use-public-contributions.ts
+++ b/apps/frontend/src/features/contributions/api/use-public-contributions/use-public-contributions.ts
@@ -11,7 +11,7 @@ type ContributionRange = 30 | 90 | 180 | 365;
 
 type UsePublicContributionsOptions = {
 	range?: ContributionRange;
-	locale?: "ja" | "en";
+	locale?: "ja" | "en" | "es";
 	queryConfig?: QueryConfig<() => Promise<ContributionSummary>>;
 };
 
@@ -19,7 +19,7 @@ type PublicContributionsClient = {
 	public: {
 		contributions: {
 			$get: (params: {
-				query: { range: string; locale: "ja" | "en" };
+				query: { range: string; locale: "ja" | "en" | "es" };
 			}) => Promise<Response>;
 		};
 	};

--- a/apps/frontend/src/features/dashboard/api/use-dashboard-overview/use-dashboard-overview.ts
+++ b/apps/frontend/src/features/dashboard/api/use-dashboard-overview/use-dashboard-overview.ts
@@ -11,7 +11,7 @@ import { extractErrorMessage, queryKeys, useHonoClient } from "@/shared/lib";
  */
 type UseDashboardOverviewOptions = {
 	/** 言語 */
-	language?: "ja" | "en";
+	language?: "ja" | "en" | "es";
 	/** React Queryの設定 */
 	queryConfig?: QueryConfig<() => Promise<DashboardOverviewResponse>>;
 };

--- a/apps/frontend/src/features/dashboard/api/use-views-trend/use-views-trend.ts
+++ b/apps/frontend/src/features/dashboard/api/use-views-trend/use-views-trend.ts
@@ -11,7 +11,7 @@ import { extractErrorMessage, queryKeys, useHonoClient } from "@/shared/lib";
  */
 type UseViewsTrendOptions = {
 	/** 言語 */
-	language?: "ja" | "en";
+	language?: "ja" | "en" | "es";
 	/** 表示期間（日数） */
 	days?: 30 | 90 | 180 | 360;
 	/** React Queryの設定 */

--- a/apps/frontend/src/features/dashboard/ui/recent-activities/recent-activities.tsx
+++ b/apps/frontend/src/features/dashboard/ui/recent-activities/recent-activities.tsx
@@ -91,7 +91,10 @@ export function RecentActivities({
 	 * 日時を相対形式で表示
 	 */
 	const formatActivityDateTime = (dateString: string): string => {
-		const dateInfo = formatRelativeDate(dateString, locale as "ja" | "en");
+		const dateInfo = formatRelativeDate(
+			dateString,
+			locale as "ja" | "en" | "es"
+		);
 
 		if (!dateInfo) return dateString;
 

--- a/apps/frontend/src/features/dashboard/ui/views-trend-chart/views-trend-chart.tsx
+++ b/apps/frontend/src/features/dashboard/ui/views-trend-chart/views-trend-chart.tsx
@@ -28,7 +28,7 @@ import { Skeleton } from "@/shared/ui/skeleton/skeleton";
  */
 interface ViewsTrendChartProps {
 	/** 言語設定 */
-	language?: "ja" | "en";
+	language?: "ja" | "en" | "es";
 	/** 選択された日数 */
 	selectedDays: 30 | 90 | 180 | 360;
 	/** Cardを表示しないオプション */

--- a/apps/frontend/src/features/gallery-management/model/columns.tsx
+++ b/apps/frontend/src/features/gallery-management/model/columns.tsx
@@ -24,7 +24,7 @@ function DateCell({ dateString }: { dateString: string | null }) {
 
 	if (!dateString) return <span className="text-muted-foreground">未設定</span>;
 
-	const dateInfo = formatRelativeDate(dateString, locale as "ja" | "en");
+	const dateInfo = formatRelativeDate(dateString, locale as "ja" | "en" | "es");
 
 	if (!dateInfo)
 		return <span className="text-muted-foreground">無効な日付</span>;

--- a/apps/frontend/src/features/lang/ui/language-switcher/language-switcher.tsx
+++ b/apps/frontend/src/features/lang/ui/language-switcher/language-switcher.tsx
@@ -15,6 +15,7 @@ import {
 const languages = [
 	{ code: "ja", label: "日本語", flag: "🇯🇵" },
 	{ code: "en", label: "English", flag: "🇺🇸" },
+	{ code: "es", label: "Español", flag: "🇪🇸" },
 ] as const;
 
 export function LanguageSwitcher() {

--- a/apps/frontend/src/middleware.middleware.test.ts
+++ b/apps/frontend/src/middleware.middleware.test.ts
@@ -6,13 +6,16 @@ import {
 } from "@/shared/lib/testing/middleware-test-utils";
 import { middleware } from "./middleware";
 
-// NextAuth.jsのgetTokenをモック
-vi.mock("next-auth/jwt", () => ({
-	getToken: vi.fn(),
+// middlewareが依存するauthモジュールをモックする。
+// 実体をimportするとnext-authが読み込まれ、テスト環境で
+// next/serverの解決に失敗するため、authごとモックしてセッションを制御する。
+const { mockAuth } = vi.hoisted(() => ({
+	mockAuth: vi.fn(),
 }));
 
-const { getToken } = await import("next-auth/jwt");
-const mockGetToken = vi.mocked(getToken);
+vi.mock("./app/api/auth/[...nextauth]/auth", () => ({
+	auth: mockAuth,
+}));
 
 describe("middleware", () => {
 	beforeEach(() => {
@@ -22,26 +25,20 @@ describe("middleware", () => {
 	describe("認証チェック機能", () => {
 		it("/adminパスへの認証済みアクセスは通常処理される", async () => {
 			// 認証済みのトークンを返す
-			mockGetToken.mockResolvedValue({
-				id: "1",
-				email: "test@example.com",
-				name: "Test",
-				picture: "",
+			mockAuth.mockResolvedValue({
+				user: { email: "test@example.com", name: "Test" },
 			});
 
 			const request = createMockNextRequest("http://localhost:3333/admin");
 			const response = await middleware(request);
 
 			expectNext(response);
-			expect(mockGetToken).toHaveBeenCalledWith({
-				req: request,
-				secret: "test-secret",
-			});
+			expect(mockAuth).toHaveBeenCalled();
 		});
 
 		it("/adminパスへの未認証アクセスはログインページへリダイレクトされる", async () => {
 			// 未認証（null）を返す
-			mockGetToken.mockResolvedValue(null);
+			mockAuth.mockResolvedValue(null);
 
 			const request = createMockNextRequest("http://localhost:3333/admin");
 			const response = await middleware(request);
@@ -53,7 +50,7 @@ describe("middleware", () => {
 		});
 
 		it("/admin/articlesへの未認証アクセスもリダイレクトされる", async () => {
-			mockGetToken.mockResolvedValue(null);
+			mockAuth.mockResolvedValue(null);
 
 			const request = createMockNextRequest(
 				"http://localhost:3333/admin/articles"
@@ -67,7 +64,7 @@ describe("middleware", () => {
 		});
 
 		it("認証チェック時にcallbackUrlが正しく設定される", async () => {
-			mockGetToken.mockResolvedValue(null);
+			mockAuth.mockResolvedValue(null);
 
 			const request = createMockNextRequest(
 				"http://localhost:3333/admin/tags?filter=tech"
@@ -109,8 +106,8 @@ describe("middleware", () => {
 			const request = createMockNextRequest("http://localhost:3333/articles");
 			const response = await middleware(request);
 
-			// デフォルトロケールは "ja"
-			expectRedirect(response, "http://localhost:3333/ja/articles");
+			// デフォルトロケールは "en"
+			expectRedirect(response, "http://localhost:3333/en/articles");
 		});
 
 		it("複数言語の優先度（q値）が正しく処理される", async () => {
@@ -134,7 +131,8 @@ describe("middleware", () => {
 			});
 			const response = await middleware(request);
 
-			expectRedirect(response, "http://localhost:3333/ja/articles");
+			// デフォルトロケールは "en"
+			expectRedirect(response, "http://localhost:3333/en/articles");
 		});
 
 		it("既にロケールが含まれている場合、リダイレクトされない", async () => {
@@ -166,29 +164,30 @@ describe("middleware", () => {
 			const response = await middleware(request);
 
 			expectNext(response);
-			// getTokenが呼ばれないことを確認
-			expect(mockGetToken).not.toHaveBeenCalled();
+			// auth()が呼ばれないことを確認
+			expect(mockAuth).not.toHaveBeenCalled();
 		});
 
 		it("/loginパスは言語ルーティングをスキップする", async () => {
+			// /loginはBasic認証で保護されているため、有効な資格情報を付与する。
+			// （環境変数未設定時のデフォルトはadmin:password）
+			const credentials = Buffer.from("admin:password").toString("base64");
 			const request = createMockNextRequest("http://localhost:3333/login", {
 				headers: {
+					authorization: `Basic ${credentials}`,
 					"accept-language": "ja-JP,ja;q=0.9",
 				},
 			});
 			const response = await middleware(request);
 
-			// リダイレクトされない
+			// ロケールリダイレクトされない
 			expectNext(response);
 		});
 
 		it("/admin/loginのような複合パスも正しく処理される", async () => {
 			// 認証済みの場合
-			mockGetToken.mockResolvedValue({
-				id: "1",
-				email: "test@example.com",
-				name: "Test",
-				picture: "",
+			mockAuth.mockResolvedValue({
+				user: { email: "test@example.com", name: "Test" },
 			});
 
 			const request = createMockNextRequest(
@@ -197,7 +196,7 @@ describe("middleware", () => {
 			const response = await middleware(request);
 
 			// /adminで始まるので認証チェックが行われる
-			expect(mockGetToken).toHaveBeenCalled();
+			expect(mockAuth).toHaveBeenCalled();
 			expectNext(response);
 		});
 	});

--- a/apps/frontend/src/shared/config/locale.ts
+++ b/apps/frontend/src/shared/config/locale.ts
@@ -20,4 +20,9 @@ export const localeItems = (
 		value: "en",
 		label: t("en"),
 	},
+	{
+		flag: "🇪🇸",
+		value: "es",
+		label: t("es"),
+	},
 ];

--- a/apps/frontend/src/shared/lib/api-client.ts
+++ b/apps/frontend/src/shared/lib/api-client.ts
@@ -137,7 +137,7 @@ export async function fetchArticles(
 		query: {
 			page: query.page,
 			limit: query.limit,
-			language: query.lang as "ja" | "en" | undefined,
+			language: query.lang as "ja" | "en" | "es" | undefined,
 			status: query.status as "published" | "draft" | "archived" | undefined,
 			search: query.search,
 			sortBy: query.sortBy as
@@ -246,7 +246,7 @@ export async function fetchAllArticles(
 		query: {
 			page: query.page,
 			limit: query.limit,
-			language: query.lang as "ja" | "en" | undefined,
+			language: query.lang as "ja" | "en" | "es" | undefined,
 			status: query.status as "published" | "draft" | "archived" | undefined,
 			search: query.search,
 			sortBy: query.sortBy as

--- a/apps/frontend/src/shared/lib/format-date/format-date.test.ts
+++ b/apps/frontend/src/shared/lib/format-date/format-date.test.ts
@@ -238,6 +238,32 @@ describe("formatRelativeDate", () => {
 			expect(result?.formatted).toBeDefined();
 		});
 
+		it("英語ロケールでは英語の月名で日付を整形する", () => {
+			// Arrange: 11日以上前の日付（通常の日付形式になる）
+			const currentDate = new Date("2024-01-31T10:00:00.000Z");
+			const isoString = "2024-01-15T10:00:00.000Z";
+
+			// Act: enロケールで整形
+			const result = formatRelativeDate(isoString, "en", currentDate);
+
+			// Assert: en-USで整形され英語の月名(January)を含む
+			expect(result?.isRelative).toBe(false);
+			expect(result?.formatted).toContain("January");
+		});
+
+		it("スペイン語ロケールではスペイン語の月名で日付を整形する", () => {
+			// Arrange: 11日以上前の日付（通常の日付形式になる）
+			const currentDate = new Date("2024-01-31T10:00:00.000Z");
+			const isoString = "2024-01-15T10:00:00.000Z";
+
+			// Act: esロケールで整形
+			const result = formatRelativeDate(isoString, "es", currentDate);
+
+			// Assert: es-ESで整形されスペイン語の月名(enero)を含む
+			expect(result?.isRelative).toBe(false);
+			expect(result?.formatted).toContain("enero");
+		});
+
 		it("入力がnullの場合はundefinedを返す", () => {
 			// Arrange: nullを用意
 			const isoString = null;

--- a/apps/frontend/src/shared/lib/format-date/format-date.ts
+++ b/apps/frontend/src/shared/lib/format-date/format-date.ts
@@ -1,4 +1,5 @@
 import type { Locale } from "@saneatsu/i18n";
+import { bcp47ByLocale } from "@saneatsu/i18n";
 
 /**
  * ISO 8601形式の日時をdatetime-local形式に変換する
@@ -134,8 +135,8 @@ export function formatRelativeDate(
 		}
 
 		// 10日より前の場合は通常の日付形式
-		// LocaleをIntl.LocalesArgument形式に変換
-		const localeCode = locale === "ja" ? "ja-JP" : "en-US";
+		// LocaleをIntl.LocalesArgument形式（BCP 47）に変換
+		const localeCode = bcp47ByLocale[locale];
 		const formatted = targetDate.toLocaleDateString(localeCode, {
 			year: "numeric",
 			month: "long",

--- a/apps/frontend/src/shared/model/article.ts
+++ b/apps/frontend/src/shared/model/article.ts
@@ -1,3 +1,5 @@
+import type { Locale } from "@saneatsu/i18n";
+
 import type { PaginationInfo } from "./common";
 import type { Tag } from "./tag";
 
@@ -8,8 +10,13 @@ export type ArticleStatus = "published" | "draft" | "archived";
 
 /**
  * 言語コード
+ *
+ * @remarks
+ * サイトのサポート言語（@saneatsu/i18n の Locale）と常に一致させるため、
+ * ロケール定義を単一のソース・オブ・トゥルースとしてエイリアスする。
+ * 言語を追加するときは config.ts の locales だけを更新すればよい。
  */
-export type LanguageCode = "ja" | "en";
+export type LanguageCode = Locale;
 
 /**
  * 記事オブジェクト（API レスポンス用）
@@ -154,6 +161,7 @@ export const ARTICLE_STATUS_CONFIG: Record<
 export const LANGUAGE_CONFIG: Record<LanguageCode, { label: string }> = {
 	ja: { label: "日本語" },
 	en: { label: "English" },
+	es: { label: "Español" },
 };
 
 /**

--- a/apps/frontend/src/shared/model/dashboard.ts
+++ b/apps/frontend/src/shared/model/dashboard.ts
@@ -13,7 +13,7 @@ import type {
  */
 export interface DashboardStatsRequestQuery {
 	/** 統計データを取得する言語 */
-	language?: "ja" | "en";
+	language?: "ja" | "en" | "es";
 	/** 時系列データの期間（日数、7-90日） */
 	timeRange?: string;
 }
@@ -23,7 +23,7 @@ export interface DashboardStatsRequestQuery {
  */
 export interface DashboardOverviewRequestQuery {
 	/** 統計データを取得する言語 */
-	language?: "ja" | "en";
+	language?: "ja" | "en" | "es";
 }
 
 /**

--- a/apps/frontend/src/shared/model/gallery.ts
+++ b/apps/frontend/src/shared/model/gallery.ts
@@ -1,9 +1,14 @@
 import type { GalleryImageStatus } from "@saneatsu/db";
+import type { Locale } from "@saneatsu/i18n";
 
 /**
  * 言語コード
+ *
+ * @remarks
+ * サイトのサポート言語（@saneatsu/i18n の Locale）と常に一致させるため、
+ * ロケール定義を単一のソース・オブ・トゥルースとしてエイリアスする。
  */
-export type LanguageCode = "ja" | "en";
+export type LanguageCode = Locale;
 
 /**
  * ギャラリー画像のステータス（再エクスポート）

--- a/apps/frontend/src/shared/model/tag.ts
+++ b/apps/frontend/src/shared/model/tag.ts
@@ -19,6 +19,15 @@ export interface Tag {
 		ja: string | null; // FIXME:
 		/** 英語の翻訳 */
 		en: string | null; // FIXME:
+		/**
+		 * スペイン語の翻訳（任意）
+		 *
+		 * @remarks
+		 * タグは英語のスラッグ的な識別子のみを自動生成しており、
+		 * スペイン語のタグ名は生成していない。そのため任意プロパティとし、
+		 * 未提供の場合は表示側で en → ja → slug の順にフォールバックする。
+		 */
+		es?: string | null;
 	};
 }
 

--- a/apps/frontend/src/shared/ui/google-maps-embed/google-maps-embed.tsx
+++ b/apps/frontend/src/shared/ui/google-maps-embed/google-maps-embed.tsx
@@ -11,7 +11,7 @@ export interface GoogleMapsEmbedProps {
 	query?: string;
 	zoom?: number;
 	mapType?: GoogleMapsMapType;
-	language?: "ja" | "en";
+	language?: "ja" | "en" | "es";
 	className?: string;
 	embedSrc?: string;
 }

--- a/apps/frontend/src/shared/ui/markdown-preview/markdown-preview.tsx
+++ b/apps/frontend/src/shared/ui/markdown-preview/markdown-preview.tsx
@@ -163,7 +163,7 @@ export interface MarkdownPreviewProps {
 	/** 表示するMarkdownコンテンツ */
 	content: string;
 	/** 言語設定（Wiki Link用） */
-	language?: "ja" | "en";
+	language?: "ja" | "en" | "es";
 	/** 追加のCSSクラス */
 	className?: string;
 	/** カスタムコンポーネント */
@@ -288,7 +288,7 @@ function hasBlockImage(children: React.ReactNode): boolean {
  * @param imageUrls - 記事内の全画像URLリスト（Lightboxナビゲーション用）
  */
 export function createDefaultMarkdownComponents(
-	language: "ja" | "en" = "ja",
+	language: "ja" | "en" | "es" = "ja",
 	imageComponent: "article" | "zoomable" = "article",
 	headings?: Array<{ id: string; text: string }>,
 	imageUrls?: string[]

--- a/apps/frontend/src/types/next-intl.d.ts
+++ b/apps/frontend/src/types/next-intl.d.ts
@@ -1,6 +1,6 @@
 import type { routing } from "@/shared/config/routing";
 
-// next-intl の useLocale() が string ではなく Locale（"ja" | "en"）を返すようにする
+// next-intl の useLocale() が string ではなく Locale（"ja" | "en" | "es"）を返すようにする
 // これにより useLocale() の戻り値に対する as キャストが不要になる
 // @see https://next-intl.dev/docs/workflows/typescript
 declare module "next-intl" {

--- a/apps/frontend/src/views/about/ui/about-blog-section.tsx
+++ b/apps/frontend/src/views/about/ui/about-blog-section.tsx
@@ -14,7 +14,7 @@ import { AnchorHeading, MarkdownPreview } from "@/shared/ui";
  */
 export function AboutBlogSection() {
 	const t = useTranslations("about.blog");
-	const locale = useLocale() as "ja" | "en";
+	const locale = useLocale() as "ja" | "en" | "es";
 
 	// 翻訳ファイルからブログの目的リストを取得
 	const purposeItems: string[] = t.raw("purpose.items") as string[];

--- a/apps/frontend/src/views/about/ui/about-view.tsx
+++ b/apps/frontend/src/views/about/ui/about-view.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { bcp47ByLocale } from "@saneatsu/i18n";
 import { ArrowRight } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
@@ -78,7 +79,7 @@ export function AboutView() {
 		refetch: refetchPublicContributions,
 	} = usePublicContributions({
 		range: 365,
-		locale: locale === "ja" ? "ja" : "en",
+		locale,
 	});
 
 	const router = useRouter();
@@ -233,7 +234,7 @@ export function AboutView() {
 								void refetchPublicContributions();
 							}}
 							copy={contributionsCopy}
-							locale={locale === "ja" ? "ja-JP" : "en-US"}
+							locale={bcp47ByLocale[locale]}
 							rangeDays={publicContributions?.days.length ?? 365}
 							headingId="contributions"
 						/>

--- a/apps/frontend/src/views/article-detail/ui/article-detail-view/article-content.tsx
+++ b/apps/frontend/src/views/article-detail/ui/article-detail-view/article-content.tsx
@@ -16,7 +16,7 @@ interface ArticleContentProps {
 	/** 記事データ */
 	article: Article;
 	/** 現在のロケール */
-	locale: "ja" | "en";
+	locale: "ja" | "en" | "es";
 	/** 記事の共有用URL */
 	articleUrl: string;
 	/** Markdownから抽出した見出し一覧 */

--- a/apps/frontend/src/views/article-detail/ui/article-detail-view/article-detail-view.tsx
+++ b/apps/frontend/src/views/article-detail/ui/article-detail-view/article-detail-view.tsx
@@ -73,7 +73,7 @@ export function ArticleDetailView({
 
 				<ArticleContent
 					article={article}
-					locale={locale as "ja" | "en"}
+					locale={locale as "ja" | "en" | "es"}
 					articleUrl={articleUrl}
 					headings={headings}
 					articleContent={article.content}

--- a/apps/frontend/src/views/article-detail/ui/article-detail-view/article-header.tsx
+++ b/apps/frontend/src/views/article-detail/ui/article-detail-view/article-header.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { bcp47ByLocale } from "@saneatsu/i18n";
 import Image from "next/image";
 import { useLocale, useTranslations } from "next-intl";
 
@@ -20,18 +21,15 @@ interface ArticleHeaderProps {
  * ロケールや翻訳、日付フォーマットは内部で取得・計算する。
  */
 export function ArticleHeader({ article }: ArticleHeaderProps) {
-	const locale = useLocale() as "ja" | "en";
+	const locale = useLocale() as "ja" | "en" | "es";
 	const t = useTranslations("article");
 
 	const publishedDate = article.publishedAt
-		? new Date(article.publishedAt).toLocaleDateString(
-				locale === "ja" ? "ja-JP" : "en-US",
-				{
-					year: "numeric",
-					month: "long",
-					day: "numeric",
-				}
-			)
+		? new Date(article.publishedAt).toLocaleDateString(bcp47ByLocale[locale], {
+				year: "numeric",
+				month: "long",
+				day: "numeric",
+			})
 		: null;
 
 	// 更新日の相対日付フォーマット
@@ -46,7 +44,11 @@ export function ArticleHeader({ article }: ArticleHeaderProps) {
 				<div className="flex flex-wrap gap-2">
 					{article.tags.map((tag) => (
 						<Badge key={tag.id} variant="outline">
-							{tag.translations[locale]}
+							{/* スペイン語などタグ翻訳が無い言語では en → ja → slug の順にフォールバック */}
+							{tag.translations[locale] ??
+								tag.translations.en ??
+								tag.translations.ja ??
+								tag.slug}
 						</Badge>
 					))}
 				</div>

--- a/apps/frontend/src/views/article-detail/ui/article-detail-wrapper.tsx
+++ b/apps/frontend/src/views/article-detail/ui/article-detail-wrapper.tsx
@@ -23,7 +23,7 @@ export async function ArticleDetailWrapper({
 }: ArticleDetailWrapperProps) {
 	try {
 		const articleResponse = await fetchArticle(slug, {
-			lang: locale as "ja" | "en",
+			lang: locale as "ja" | "en" | "es",
 		});
 
 		return <ArticleDetailView article={articleResponse.data} locale={locale} />;

--- a/apps/frontend/src/widgets/articles-list/ui/articles-list.tsx
+++ b/apps/frontend/src/widgets/articles-list/ui/articles-list.tsx
@@ -49,7 +49,7 @@ export function ArticlesList({ limit }: ArticlesListProps) {
 		refetch,
 	} = useGetAllArticles({
 		page: limit ? 1 : page, // limitが指定されている場合は常に1ページ目
-		language: locale as "ja" | "en",
+		language: locale as "ja" | "en" | "es",
 		limit: limit || 24,
 		status: ["published"],
 		sortBy: "updatedAt",

--- a/apps/frontend/src/widgets/articles-list/ui/tag-filter/tag-filter.tsx
+++ b/apps/frontend/src/widgets/articles-list/ui/tag-filter/tag-filter.tsx
@@ -86,7 +86,7 @@ export function TagFilter() {
 			.filter((tag) => tag.articleCount > 0)
 			.map((tag) => ({
 				label:
-					tag.translations[locale as "ja" | "en"] ||
+					tag.translations[locale as "ja" | "en" | "es"] ||
 					tag.translations.ja ||
 					tag.slug,
 				value: tag.id.toString(),

--- a/apps/frontend/src/widgets/popular-articles-list/ui/popular-articles-list.tsx
+++ b/apps/frontend/src/widgets/popular-articles-list/ui/popular-articles-list.tsx
@@ -21,7 +21,7 @@ export function PopularArticlesList() {
 		refetch,
 	} = useGetAllArticles({
 		page: 1,
-		language: locale as "ja" | "en",
+		language: locale as "ja" | "en" | "es",
 		limit: 10, // トップ10を表示
 		status: ["published"],
 		sortBy: "viewCount", // 閲覧数でソート

--- a/apps/frontend/vitest.config.middleware.mts
+++ b/apps/frontend/vitest.config.middleware.mts
@@ -2,6 +2,25 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
+/**
+ * ミドルウェア専用のVitest設定。
+ *
+ * メインのvitest.config.mtsとは意図的に分離している。理由は以下の2点で、
+ * どちらも「両立できないグローバル設定」を要求するため同居できない。
+ *
+ * 1. 実行環境の違い
+ *    メインはReactコンポーネント向けにjsdom環境。ミドルウェアはサーバー/Edgeで
+ *    動くコードなのでnode環境が必要。
+ * 2. next/serverのモックの有無
+ *    メインのsetup(vitest.setup.mts)はnext/serverをグローバルにモックしており、
+ *    NextResponse.redirect/nextが空関数(undefinedを返す)になる。一方この
+ *    ミドルウェアテストは本物のNextResponse(status・locationヘッダー)を検証する
+ *    ため、モックされていないnext/serverが必要。
+ *
+ * そのためメイン設定では`*.middleware.test.*`を除外し、こちらは
+ * `pnpm test:middleware`として実行する(CIでも個別ステップで実行する)。
+ */
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({

--- a/apps/frontend/vitest.config.mts
+++ b/apps/frontend/vitest.config.mts
@@ -20,6 +20,11 @@ export default defineConfig({
 			"dist/**",
 			"build/**",
 			"**/*.stories.{js,jsx,ts,tsx}",
+			// ミドルウェアテストは別設定(vitest.config.middleware.mts)で実行するため除外する。
+			// 理由: このメイン設定はjsdom環境で、setup(vitest.setup.mts)がnext/serverを
+			// グローバルにモックしている。一方ミドルウェアテストはnode環境かつ本物の
+			// NextResponse(status/locationヘッダー)の検証が必要で、両者は両立しない
+			// グローバル設定を要求するため分離している。CIでは`pnpm test:middleware`で個別実行する。
 			"**/*.middleware.test.{js,ts,mjs,mts}",
 			"**/*.bak/**",
 		],

--- a/apps/frontend/vitest.setup.middleware.ts
+++ b/apps/frontend/vitest.setup.middleware.ts
@@ -4,6 +4,12 @@ import { vi } from "vitest";
 process.env.NEXTAUTH_SECRET = "test-secret";
 process.env.NEXTAUTH_URL = "http://localhost:3000";
 
+// /loginのBasic認証で参照される資格情報。
+// 未設定だとmiddlewareがEdge Runtime向けの`self`フォールバックまで
+// 評価してしまい、node環境では`self is not defined`で落ちるため明示的に設定する。
+process.env.BASIC_AUTH_USER = "admin";
+process.env.BASIC_AUTH_PASSWORD = "password";
+
 // console.logのモック（テスト出力をクリーンに保つ）
 global.console = {
 	...console,

--- a/packages/db/src/schema/article_translations.ts
+++ b/packages/db/src/schema/article_translations.ts
@@ -15,8 +15,8 @@ export const articleTranslations = sqliteTable(
 		title: text("title").notNull(),
 		/** Markdown形式の本文 */
 		content: text("content").notNull(),
-		/** 言語コード（ja: 日本語, en: 英語） */
-		language: text("language", { enum: ["ja", "en"] }).notNull(),
+		/** 言語コード（ja: 日本語, en: 英語, es: スペイン語） */
+		language: text("language", { enum: ["ja", "en", "es"] }).notNull(),
 		/** 記事ID（外部キー） */
 		articleId: integer("article_id")
 			.notNull()

--- a/packages/db/src/schema/gallery-image-translations.ts
+++ b/packages/db/src/schema/gallery-image-translations.ts
@@ -22,8 +22,8 @@ export const galleryImageTranslations = sqliteTable(
 		galleryImageId: integer("gallery_image_id")
 			.notNull()
 			.references(() => galleryImages.id, { onDelete: "cascade" }),
-		/** 言語コード（ja, en） */
-		language: text("language", { enum: ["ja", "en"] }).notNull(),
+		/** 言語コード（ja, en, es） */
+		language: text("language", { enum: ["ja", "en", "es"] }).notNull(),
 		/** 画像タイトル */
 		title: text("title"),
 		/** 画像の説明 */

--- a/packages/db/src/schema/tag_translations.ts
+++ b/packages/db/src/schema/tag_translations.ts
@@ -11,8 +11,8 @@ export const tagTranslations = sqliteTable("tag_translations", {
 	id: integer("id").primaryKey({ autoIncrement: true }),
 	/** タグ名 */
 	name: text("name").notNull(),
-	/** 言語コード（ja: 日本語, en: 英語） */
-	language: text("language", { enum: ["ja", "en"] }).notNull(),
+	/** 言語コード（ja: 日本語, en: 英語, es: スペイン語） */
+	language: text("language", { enum: ["ja", "en", "es"] }).notNull(),
 	/** タグID（外部キー） */
 	tagId: integer("tag_id")
 		.notNull()

--- a/packages/i18n/src/config.ts
+++ b/packages/i18n/src/config.ts
@@ -3,7 +3,9 @@
  */
 
 export const locales = ["ja", "en"] as const;
-export const defaultLocale = "ja" as const;
+// ブラウザの言語が未対応・不明な場合のフォールバック先。
+// 日本語以外のユーザーにも読めるよう、既定は英語（en）とする。
+export const defaultLocale = "en" as const;
 
 export type Locale = (typeof locales)[number];
 

--- a/packages/i18n/src/config.ts
+++ b/packages/i18n/src/config.ts
@@ -2,7 +2,7 @@
  * next-intl設定
  */
 
-export const locales = ["ja", "en"] as const;
+export const locales = ["ja", "en", "es"] as const;
 // ブラウザの言語が未対応・不明な場合のフォールバック先。
 // 日本語以外のユーザーにも読めるよう、既定は英語（en）とする。
 export const defaultLocale = "en" as const;
@@ -17,3 +17,30 @@ export const i18nConfig = {
 	defaultLocale,
 	localePrefix: "as-needed",
 } as const;
+
+/**
+ * ロケール → BCP 47 言語タグ（`Intl` / `toLocaleDateString` 用）の対応表
+ *
+ * @description
+ * `new Date().toLocaleDateString(locale)` などに渡すロケール文字列を、
+ * サイトのロケールコードから一元的に解決するためのマップ。
+ * 言語を追加したらここに1行足すだけでよい（三項演算子の分岐漏れを防ぐ）。
+ */
+export const bcp47ByLocale: Record<Locale, string> = {
+	ja: "ja-JP",
+	en: "en-US",
+	es: "es-ES",
+};
+
+/**
+ * ロケール → Open Graph の `og:locale` 値の対応表
+ *
+ * @description
+ * Open Graph は `ja_JP` のようにアンダースコア区切りの表記を用いるため、
+ * BCP 47（ハイフン区切り）とは別に定義する。
+ */
+export const openGraphLocaleByLocale: Record<Locale, string> = {
+	ja: "ja_JP",
+	en: "en_US",
+	es: "es_ES",
+};

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -16,12 +16,14 @@
 	"language": {
 		"japanese": "日本語",
 		"english": "English",
+		"spanish": "Español",
 		"switch": "Switch language"
 	},
 	"LocaleSwitcher": {
 		"label": "Switch language",
 		"ja": "日本語",
-		"en": "English"
+		"en": "English",
+		"es": "Español"
 	},
 	"home": {
 		"hero": {

--- a/packages/i18n/src/locales/es.json
+++ b/packages/i18n/src/locales/es.json
@@ -1,0 +1,771 @@
+{
+	"navigation": {
+		"home": "Inicio",
+		"blog": "Blog",
+		"about": "Perfil",
+		"gallery": "Galería",
+		"contact": "Contacto",
+		"top": "Arriba"
+	},
+	"theme": {
+		"light": "Claro",
+		"dark": "Oscuro",
+		"system": "Sistema",
+		"toggle": "Cambiar tema"
+	},
+	"language": {
+		"japanese": "日本語",
+		"english": "English",
+		"spanish": "Español",
+		"switch": "Cambiar idioma"
+	},
+	"LocaleSwitcher": {
+		"label": "Cambiar idioma",
+		"ja": "日本語",
+		"en": "English",
+		"es": "Español"
+	},
+	"home": {
+		"hero": {
+			"title": "saneatsu.me",
+			"description": "CEO de ALIA LLC e ingeniero al que le encanta crear cosas. Trabajo en todo el stack —frontend, backend y móvil— y cuido los detalles, buscando productos que resulten agradables de usar. Aquí escribo sobre las cosas en las que pienso cada día.",
+			"aboutPrompt": "Para conocer un perfil más completo y mi trayectoria,",
+			"aboutLink": "visita el Perfil",
+			"contactPrompt": "Abierto a propuestas de trabajo: no dudes en escribirme",
+			"contactLink": "Contacto",
+			"photoAlt": "Foto de perfil de saneatsu"
+		},
+		"popularArticles": {
+			"title": "Artículos populares"
+		},
+		"articles": {
+			"title": "Últimos artículos"
+		}
+	},
+	"blog": {
+		"title": "Blog",
+		"tagFilter": {
+			"title": "Etiquetas",
+			"selected": "seleccionadas",
+			"placeholder": "Etiquetas",
+			"noResults": "No se encontraron resultados",
+			"clear": "Limpiar",
+			"clearLabel": "Limpiar filtro de etiquetas"
+		}
+	},
+	"about": {
+		"title": "Perfil",
+		"blog": {
+			"title": "Sobre este blog",
+			"purpose": {
+				"title": "Propósito",
+				"items": [
+					"Compartir información técnica",
+					"Registrar lo que voy aprendiendo",
+					"Portafolio",
+					"Ordenar mis ideas y compartirlas y estructurarlas con el equipo"
+				]
+			},
+			"history": {
+				"title": "Historia",
+				"content": "El desarrollo comenzó en julio de 2025. Para más detalles sobre el stack técnico y la motivación, consulta el artículo [Creé un sitio llamado saneatsu.me](/es/blog/made-this-site)."
+			},
+			"policy": {
+				"title": "Política editorial",
+				"principle1": "Los artículos se publican sin esperar a que sean perfectos y se actualizan de forma continua. El contenido refleja el momento en que se escribió y puede cambiar con el tiempo",
+				"principle2": "Este enfoque está inspirado en la cultura de transparencia de GitLab",
+				"bookLink": "The GitLab Handbook (buenas prácticas de trabajo remoto)"
+			}
+		},
+		"author": {
+			"title": "Sobre mí",
+			"profile": {
+				"title": "Perfil",
+				"content": "Soy un ingeniero nacido en Yamagata, criado en Hokkaido y actualmente afincado en Tokio. Soy el CEO de ALIA LLC. Para más detalles, consulta la sección «Trayectoria» más abajo."
+			},
+			"interests": {
+				"title": "Intereses y aficiones",
+				"hobbies": "Llevo mucho tiempo creando software, pero también disfruto de manualidades como el ikebana (escuela Sogetsu)."
+			}
+		},
+		"tech": {
+			"title": "Stack técnico",
+			"languages": {
+				"title": "Lenguajes"
+			},
+			"frameworks": {
+				"title": "Frameworks y librerías"
+			},
+			"databases": {
+				"title": "Bases de datos"
+			},
+			"tools": {
+				"title": "Herramientas de desarrollo"
+			}
+		},
+		"experience": {
+			"title": "Trayectoria",
+			"category": {
+				"work": "Trabajo",
+				"education": "Formación",
+				"project": "Proyecto",
+				"skill": "Habilidad"
+			},
+			"detail": {
+				"title": "Detalles de la experiencia",
+				"period": "Periodo",
+				"employmentType": "Tipo de contrato",
+				"role": "Rol",
+				"category": "Categoría",
+				"description": "Detalles del trabajo",
+				"content": "Contenido de la actividad",
+				"techStack": "Stack técnico",
+				"other": "Otros",
+				"present": "Actualidad"
+			},
+			"timeline": [
+				{
+					"slug": "activecore",
+					"period": {
+						"from": "2026-04",
+						"to": null
+					},
+					"companyName": "activecore, Inc.",
+					"role": [
+						"Product Manager",
+						"Ingeniero Frontend",
+						"Ingeniero Backend"
+					],
+					"employmentType": "Contrato",
+					"description": [
+						{
+							"title": "Descripción del producto",
+							"content": "Desarrollo de un sistema web que analiza datos de compra para prever y recomendar productos.\n\nTrabajo en remoto y, aunque hay un equipo, opero de forma bastante independiente. En lugar de que me asignen tareas, descubro problemas por mí mismo de forma continua y creo productos para validar hipótesis.",
+							"techStack": ["Remix", "React", "Tailwind CSS", "shadcn/ui"]
+						},
+						{
+							"title": "Product Manager / Ingeniero",
+							"content": "- Me encargo por mi cuenta de todo el ciclo, desde el descubrimiento del problema hasta la validación de la hipótesis\n- Realizo tareas de gestión de producto (encontrar problemas, formular hipótesis, priorizar)\n- Implemento tanto el frontend como el backend"
+						}
+					],
+					"category": "work",
+					"logoUrls": ["/company-logo/activecore-logo.png"]
+				},
+				{
+					"slug": "mobile-order-lab-and-tacoms",
+					"period": {
+						"from": "2025-03",
+						"to": "2026-03"
+					},
+					"companyName": "Mobile Order Lab, Inc.・tacoms, Inc.",
+					"role": ["Asesor", "Scrum Master", "Tech Lead", "Ingeniero Frontend"],
+					"employmentType": "Contrato",
+					"description": [
+						{
+							"title": "Sobre la integración de negocios",
+							"content": "Dado que Mobile Order Lab, Inc. y tacoms, Inc. se han fusionado, mostramos los logotipos de ambas empresas.\n\nPara más detalles, consulta el [comunicado de prensa sobre la integración de negocios](https://prtimes.jp/main/html/rd/p/000000047.000077961.html)."
+						},
+						{
+							"title": "Autónomo",
+							"content": "Trabajando 4 horas al día. Aunque escribí código, mi función principal era reforzar las capacidades base del equipo de frontend y actuar como asesor del equipo de desarrollo.\n\nCompartí distintas ideas sobre qué podíamos hacer para mejorar y, mientras escribía código concreto, contribuí a construir una cultura de equipo en la que aprendemos y mejoramos de forma continua para desarrollar mejor.",
+							"techStack": [
+								"Next.js",
+								"Tailwind CSS",
+								"Vitest",
+								"Storybook",
+								"Playwright"
+							]
+						},
+						{
+							"title": "Asesor",
+							"content": "- Facilitar retrospectivas\n- Definir objetivos de producto\n- Leer y comentar la Guía de Scrum\n- Diseñar reuniones eficaces\n- Organizar hojas de ruta\n- Introducir la IA y compartir conocimiento"
+						},
+						{
+							"title": "Product Owner / Scrum Master",
+							"content": "- Introduje GitHub Project para organizar el backlog\n- Diseñé sesiones de Refinamiento eficaces\n- Impartí sesiones de estudio sobre Scrum"
+						},
+						{
+							"title": "Ingeniero líder",
+							"content": "- Diseñé la arquitectura general del frontend\n- Construí la infraestructura de pruebas desde cero (antes era inexistente), impartí sesiones de estudio y la integré en el ciclo de desarrollo\n  - Vitest, Storybook, Playwright\n- Introduje Feature-Slice Design\n- Construí una cultura de refactorización aumentando las pruebas y dividiendo componentes grandes en piezas de tamaño adecuado\n- Impartí sesiones de estudio sobre Cycle Time y Four Keys, visualicé las métricas y realicé retrospectivas semanales para mejorar el ciclo de aprendizaje del equipo\n- Reduje el lead time\n- Impartí sesiones de estudio\n  - Las sesiones de estudio semanales se siguen celebrando incluso después de dejar el equipo"
+						}
+					],
+					"category": "work",
+					"logoUrls": [
+						"/company-logo/mobile-order-lab-logo.png",
+						"/company-logo/tacoms-logo.webp"
+					]
+				},
+				{
+					"slug": "algoage-inc",
+					"period": {
+						"from": "2018-07",
+						"to": "2025-02"
+					},
+					"companyName": "Algoage, Inc.",
+					"role": [
+						"Project Manager",
+						"Product Manager",
+						"Tech Lead",
+						"Scrum Master",
+						"Ingeniero Frontend",
+						"Ingeniero Backend",
+						"Ingeniero Móvil",
+						"Diseñador Web",
+						"Ingeniero de Machine Learning"
+					],
+					"description": [
+						{
+							"title": "2023-09: Creación de un editor de flujos de ramificación de chat",
+							"content": "Creación de un editor que facilita crear flujos de ramificación de chat y previsualizarlos en la interfaz de LINE.\n\nPara mejorar de raíz las operaciones, analicé e identifiqué los cuellos de botella principales y creé un producto de demostración en una semana yo solo, lanzándolo internamente.\nContinué el desarrollo en mi tiempo libre y, a partir de noviembre de 2023, el producto fue reconocido y el equipo se puso en marcha. Creé un editor rico para diseñar flujos usando Next.js y React Flow. Con un equipo que incluía a un ingeniero de primer año, creamos un producto v0.1 en unos 8 meses, reduciendo el lead time hasta un 75 %.",
+							"techStack": [
+								"Next.js",
+								"React Flow",
+								"Tailwind CSS",
+								"shadcn/ui",
+								"Vercel"
+							]
+						},
+						{
+							"title": "2020-09: Desarrollo de DMM Chat Boost CV",
+							"content": "Desarrollo de [DMM Chat Boost CV](https://chatboost.dmm.com/cv/).",
+							"techStack": ["Vue.js", "PrimeVue", "Rails", "AWS", "Cloudflare"],
+							"other": "En febrero de 2020 nos convertimos en filial de DMM y, al mismo tiempo, trasladamos la oficina a la actual ubicación de Yushima.\nAumentamos el número de empleados hasta unos 200 y el desarrollo comenzó en serio usando Scrum, con asesores invitados."
+						},
+						{
+							"title": "2019-10: Desarrollo de una app de salud para una constructora",
+							"content": "Desarrollo de una app de salud para una empresa constructora.",
+							"techStack": ["Nuxt", "Vuetify", "AWS", "Flutter"]
+						},
+						{
+							"title": "2019-06: Creación de una app de transcripción de audio de reuniones",
+							"content": "Creación de una app de transcripción de audio de reuniones.",
+							"techStack": [
+								"Python",
+								"Flask",
+								"OpenCV",
+								"Keras",
+								"TensorFlow",
+								"PyTorch"
+							],
+							"other": "Alquilamos una oficina de 1K en Mita, y los tres miembros de la empresa vivíamos en el mismo edificio de apartamentos cercano (plantas 4, 5 y 7) e íbamos a trabajar juntos."
+						},
+						{
+							"title": "2018-12: Desarrollo de un sistema de generación de vídeo de personajes",
+							"content": "Desarrollo de un sistema que genera vídeos de un personaje en movimiento a partir de una sola imagen de busto del personaje como entrada.",
+							"techStack": [
+								"Python",
+								"Flask",
+								"OpenCV",
+								"Keras",
+								"TensorFlow",
+								"PyTorch"
+							]
+						},
+						{
+							"title": "2018-07: Desarrollo de un sistema para crear planos de habitaciones a partir de varias fotos",
+							"content": "Desarrollo de un sistema para crear planos de habitaciones a partir de varias fotos.",
+							"techStack": [
+								"Python",
+								"OpenCV",
+								"Keras",
+								"TensorFlow",
+								"PyTorch"
+							],
+							"other": "En aquel momento aún no teníamos oficina, así que básicamente trabajábamos en casa del fundador con dos escritorios juntos.\nComo todos los miembros de la empresa eran miembros iniciales pertenecientes a [KERNEL](https://deepcore.jp/kernel), de vez en cuando también empezamos a trabajar en [KERNEL HONGO](https://ut-base.info/facilities/8).\nAdemás, dentro de la empresa, por turnos leíamos y presentábamos artículos relacionados con el machine learning cada semana."
+						}
+					],
+					"category": "work",
+					"logoUrls": ["/company-logo/algoage-logo.webp"],
+					"employmentType": "Empleado a tiempo completo"
+				},
+				{
+					"slug": "accenture",
+					"period": {
+						"from": "2017-08",
+						"to": "2018-06"
+					},
+					"companyName": "Accenture",
+					"role": [
+						"Project Manager",
+						"Ingeniero Frontend",
+						"Ingeniero Backend"
+					],
+					"description": [
+						{
+							"title": "2018-02: Sistema de detección de anomalías con IA para fábrica",
+							"content": "Desarrollé un sistema que detecta anomalías en las líneas de producción de fábricas mediante análisis de imágenes.",
+							"techStack": ["Python", "Django"]
+						},
+						{
+							"title": "2017-12: Desarrollo de producto interno",
+							"content": "Desarrollé productos internos en SONY, desde la definición de requisitos hasta la implementación.",
+							"techStack": ["VBA"]
+						}
+					],
+					"category": "work",
+					"logoUrls": ["/company-logo/accenture-logo.svg"],
+					"employmentType": "Empleado a tiempo completo"
+				}
+			]
+		},
+		"contributions": {
+			"title": "Escribiendo caracteres",
+			"description": "Un vistazo a mi volumen de escritura en japonés durante los últimos 365 días.",
+			"cta": "Leer más publicaciones"
+		},
+		"recommendedArticles": {
+			"title": "Mi forma de trabajar",
+			"description": "Cómo enfoco mi trabajo y qué es lo que más valoro. Escribo sobre las cosas en las que pienso a través de mi trabajo y aprendizaje diarios. Espero que te dé una idea de quién soy."
+		},
+		"contact": {
+			"title": "Redes sociales y sitios web",
+			"dmNote": "(¡La forma más rápida de contactarme!)"
+		},
+		"hire": {
+			"title": "Trabaja conmigo",
+			"description": "Estoy disponible para desarrollo de apps y web, y para dar apoyo como asesor o tech lead a equipos de desarrollo. No dudes en escribirme.",
+			"cta": "Ir al formulario de contacto"
+		}
+	},
+	"contact": {
+		"title": "Contacto",
+		"description": "No dudes en escribirme a través del siguiente formulario para cualquier pregunta o consulta.",
+		"required": "Obligatorio",
+		"name": {
+			"label": "Nombre",
+			"placeholder": "Juan Pérez"
+		},
+		"company": {
+			"label": "Empresa",
+			"placeholder": "Example Inc."
+		},
+		"jobTitle": {
+			"label": "Cargo",
+			"placeholder": "Ingeniero (opcional)"
+		},
+		"email": {
+			"label": "Correo electrónico",
+			"placeholder": "example@email.com"
+		},
+		"subject": {
+			"label": "Asunto",
+			"placeholder": "Asunto de tu consulta"
+		},
+		"category": {
+			"label": "Categoría",
+			"placeholder": "Selecciona una categoría",
+			"options": {
+				"business": "Negocio / Colaboración",
+				"feedback": "Comentarios",
+				"bug-report": "Informe de error",
+				"other": "Otro"
+			}
+		},
+		"message": {
+			"label": "Mensaje",
+			"placeholder": "Escribe tu mensaje"
+		},
+		"submit": "Enviar",
+		"submitting": "Enviando...",
+		"submitted": "Enviado",
+		"success": {
+			"title": "Enviado correctamente",
+			"message": "Gracias por tu consulta. Te responderé lo antes posible.",
+			"sendAnother": "Enviar otra consulta"
+		},
+		"error": {
+			"submitFailed": "No se pudo enviar. Inténtalo de nuevo más tarde."
+		}
+	},
+	"contributions": {
+		"title": "Actividad de escritura",
+		"subtitle": "Caracteres japoneses en los últimos 365 días",
+		"rangeLabel": "Últimos {days} días",
+		"summary": {
+			"totalJaChars": "Caracteres japoneses"
+		},
+		"legend": {
+			"less": "Menos",
+			"more": "Más"
+		},
+		"error": "No se pudo cargar la actividad de escritura",
+		"retry": "Reintentar",
+		"units": {
+			"jaChars": "caracteres"
+		}
+	},
+	"footer": {
+		"copyright": "© {year} Saneatsu WAKANA. Todos los derechos reservados.",
+		"privacy": "Política de privacidad",
+		"terms": "Términos del servicio"
+	},
+	"admin": {
+		"articles": {
+			"new": {
+				"title": "Crear nuevo artículo - Administración",
+				"description": "Crear un nuevo artículo"
+			}
+		},
+		"gallery": {
+			"title": "Gestión de la galería",
+			"description": "Gestionar y subir imágenes",
+			"list": {
+				"title": "Lista de la galería - Administración",
+				"description": "Lista de imágenes de la galería",
+				"empty": "No se encontraron imágenes",
+				"newImage": "Añadir nueva imagen"
+			},
+			"new": {
+				"title": "Subir imagen - Administración",
+				"description": "Subir una nueva imagen"
+			},
+			"edit": {
+				"title": "Editar imagen - Administración",
+				"description": "Editar la información de la imagen"
+			}
+		}
+	},
+	"loading": "Cargando...",
+	"error": {
+		"title": "Se produjo un error",
+		"message": "Lo sentimos, se ha producido un error inesperado.",
+		"retry": "Reintentar",
+		"goHome": "Ir al inicio"
+	},
+	"article": {
+		"publishedAt": "Publicado",
+		"updatedAt": "Actualizado",
+		"viewCount": "Visto {count} veces",
+		"readMore": "Leer más",
+		"backToList": "Volver a los artículos",
+		"justNow": "Justo ahora",
+		"minutesAgo": "hace {minutes} minutos",
+		"hoursAgo": "hace {hours} horas",
+		"today": "Hoy",
+		"daysAgo": "hace {days} días",
+		"notFound": {
+			"title": "Artículo no encontrado",
+			"message": "El artículo que buscas no existe o puede que se haya eliminado."
+		},
+		"relatedArticles": {
+			"title": "Artículos relacionados",
+			"loading": "Cargando...",
+			"error": "No se pudieron cargar los artículos relacionados"
+		},
+		"tableOfContents": "Índice de contenidos"
+	},
+	"gallery": {
+		"title": "Galería",
+		"form": {
+			"file": "Archivo de imagen",
+			"fileSelect": "Seleccionar archivo",
+			"fileHelp": "Puedes subir imágenes JPEG, PNG, GIF o WebP (máx. 10 MB)",
+			"address": "Dirección",
+			"addressPlaceholder": "Shibuya, Tokio...",
+			"addressHelp": "Buscar coordenadas a partir de la dirección",
+			"searchAddress": "Buscar dirección",
+			"coordinates": "Coordenadas",
+			"latitude": "Latitud",
+			"longitude": "Longitud",
+			"latitudePlaceholder": "35.6762",
+			"longitudePlaceholder": "139.6503",
+			"coordinatesHelp": "Haz clic en el mapa para fijar las coordenadas",
+			"takenAt": "Fecha de la toma",
+			"takenAtPlaceholder": "Selecciona la fecha de la toma...",
+			"titleJa": "Título (japonés)",
+			"titleJaPlaceholder": "東京タワーの夜景",
+			"titleEn": "Título (inglés)",
+			"titleEnPlaceholder": "Tokyo Tower at Night",
+			"descriptionJa": "Descripción (japonés)",
+			"descriptionJaPlaceholder": "東京のシンボル、東京タワーがライトアップされた美しい夜景",
+			"descriptionEn": "Descripción (inglés)",
+			"descriptionEnPlaceholder": "The iconic Tokyo Tower illuminated beautifully at night",
+			"submit": "Subir",
+			"update": "Actualizar",
+			"cancel": "Cancelar",
+			"delete": "Eliminar",
+			"deleteConfirm": "¿Seguro que quieres eliminar esta imagen?",
+			"uploading": "Subiendo...",
+			"updating": "Actualizando...",
+			"deleting": "Eliminando..."
+		},
+		"message": {
+			"uploadSuccess": "Imagen subida correctamente",
+			"uploadError": "No se pudo subir la imagen",
+			"updateSuccess": "Imagen actualizada correctamente",
+			"updateError": "No se pudo actualizar la imagen",
+			"deleteSuccess": "Imagen eliminada correctamente",
+			"deleteError": "No se pudo eliminar la imagen",
+			"geocodingSuccess": "Coordenadas obtenidas a partir de la dirección",
+			"geocodingError": "No se pudieron obtener las coordenadas a partir de la dirección",
+			"geocodingNoResults": "No se encontró ninguna dirección coincidente"
+		},
+		"table": {
+			"image": "Imagen",
+			"title": "Título",
+			"location": "Ubicación",
+			"takenAt": "Fecha de la toma",
+			"createdAt": "Fecha de creación",
+			"actions": "Acciones",
+			"noLocation": "Sin ubicación",
+			"noDate": "Fecha desconocida"
+		},
+		"notFound": {
+			"title": "Imagen no encontrada",
+			"message": "La imagen que buscas no existe o puede que se haya eliminado."
+		}
+	},
+	"share": {
+		"copyLink": "Enlace copiado",
+		"copyLinkError": "No se pudo copiar el enlace",
+		"copyLinkTooltip": "Copiar el enlace del artículo",
+		"shareOnX": "Publicar en X",
+		"shareOnFacebook": "Publicar en Facebook",
+		"addToHatena": "Añadir a Hatena Bookmark",
+		"copyMarkdownSuccess": "¡Copiado!",
+		"copyMarkdownError": "No se pudo copiar el Markdown. Inténtalo de nuevo",
+		"copyMarkdownTooltip": "Copiar Markdown"
+	},
+	"articleChat": {
+		"title": "Chat con IA",
+		"beta": "Beta",
+		"close": "Cerrar chat",
+		"expand": "Expandir chat",
+		"collapse": "Contraer chat",
+		"description": "Puedes hacer preguntas sobre todos los artículos",
+		"openChat": "Preguntar sobre el artículo",
+		"inputPlaceholder": "Escribe tu pregunta",
+		"inputLabel": "Campo de la pregunta",
+		"send": "Enviar",
+		"hint": {
+			"mac": "⌘+Enter para enviar",
+			"win": "Ctrl+Enter para enviar"
+		},
+		"quickAction": {
+			"summarize": "Por favor, resume este artículo",
+			"summarizeLabel": "Resumir artículo"
+		},
+		"retry": "Reintentar",
+		"error": {
+			"fetchFailed": "No se pudo obtener respuesta. Inténtalo de nuevo",
+			"unknown": "Se produjo un error inesperado. Inténtalo de nuevo",
+			"INVALID_REQUEST": "El formato de la solicitud no es válido. Inténtalo de nuevo",
+			"REQUIRED_FIELDS": "Se requiere una pregunta. Revisa lo que has escrito",
+			"MESSAGE_TOO_LONG": "Por favor, limita tu pregunta a {maxLength} caracteres",
+			"AI_UNAVAILABLE": "Las funciones de IA no están disponibles en este momento. Contacta con el administrador",
+			"RATE_LIMIT_EXCEEDED": "Se alcanzó el límite de solicitudes de la API. Espera un momento e inténtalo de nuevo",
+			"GENERATION_FAILED": "Se produjo un error al generar la respuesta de la IA. Inténtalo de nuevo",
+			"ARTICLES_FETCH_FAILED": "No se pudo obtener la información del artículo. Inténtalo de nuevo"
+		}
+	},
+	"common": {
+		"required": "Obligatorio",
+		"search": "Buscar",
+		"filterByStatus": "Filtrar por estado",
+		"allStatus": "Todos",
+		"published": "Publicado",
+		"draft": "Borrador",
+		"clearFilters": "Limpiar filtros",
+		"blogNotice": {
+			"title": "Sobre este blog",
+			"principle1": "Los artículos se publican sin esperar a que sean perfectos y se actualizan de forma continua. El contenido refleja el momento en que se escribió y puede cambiar con el tiempo",
+			"principle3": "Este enfoque está inspirado en la cultura de transparencia de GitLab",
+			"bookLink": "The GitLab Handbook (buenas prácticas de trabajo remoto)"
+		}
+	},
+	"pagination": {
+		"previous": "Anterior",
+		"next": "Siguiente",
+		"pageIndicator": "Página {page} de {totalPages}",
+		"viewAllArticles": "Ver todos los artículos"
+	},
+	"articlesList": {
+		"loadFailed": "No se pudieron cargar los artículos.",
+		"retry": "Reintentar",
+		"empty": "No se encontraron artículos."
+	},
+	"validation": {
+		"required": "Este campo es obligatorio",
+		"tooSmall": {
+			"string": {
+				"exact": "Debe tener exactamente {minimum} caracteres",
+				"inclusive": "Debe tener al menos {minimum} caracteres",
+				"notInclusive": "Debe tener más de {minimum} caracteres"
+			},
+			"number": {
+				"exact": "Debe ser exactamente {minimum}",
+				"inclusive": "Debe ser al menos {minimum}",
+				"notInclusive": "Debe ser mayor que {minimum}"
+			},
+			"array": {
+				"exact": "Debe tener exactamente {minimum} elementos",
+				"inclusive": "Debe tener al menos {minimum} elementos",
+				"notInclusive": "Debe tener más de {minimum} elementos"
+			}
+		},
+		"tooBig": {
+			"string": {
+				"exact": "Debe tener exactamente {maximum} caracteres",
+				"inclusive": "Debe tener como máximo {maximum} caracteres",
+				"notInclusive": "Debe tener menos de {maximum} caracteres"
+			},
+			"number": {
+				"exact": "Debe ser exactamente {maximum}",
+				"inclusive": "Debe ser como máximo {maximum}",
+				"notInclusive": "Debe ser menor que {maximum}"
+			},
+			"array": {
+				"exact": "Debe tener exactamente {maximum} elementos",
+				"inclusive": "Debe tener como máximo {maximum} elementos",
+				"notInclusive": "Debe tener menos de {maximum} elementos"
+			}
+		},
+		"invalidType": {
+			"string": "Debe ser una cadena de texto",
+			"number": "Debe ser un número",
+			"boolean": "Debe ser un valor booleano",
+			"date": "Debe ser una fecha",
+			"object": "Debe ser un objeto",
+			"array": "Debe ser una lista"
+		},
+		"invalidString": {
+			"email": "Introduce una dirección de correo electrónico válida",
+			"url": "Introduce una URL válida",
+			"uuid": "Introduce un UUID válido",
+			"datetime": "Introduce una fecha y hora válidas",
+			"date": "Introduce una fecha válida",
+			"time": "Introduce una hora válida",
+			"ip": "Introduce una dirección IP válida",
+			"regex": "Formato no válido"
+		},
+		"custom": {
+			"article": {
+				"titleRequired": "Introduce un título",
+				"titleTooLong": "El título debe tener 200 caracteres o menos",
+				"contentRequired": "Introduce el contenido",
+				"contentTooLong": "El contenido debe tener 50000 caracteres o menos",
+				"slugRequired": "Introduce un slug",
+				"slugInvalid": "El slug debe empezar por una letra minúscula o un número, con guiones simples entre palabras",
+				"atLeastOneTranslation": "Crea el artículo al menos en un idioma",
+				"maxTranslations": "Admite hasta 2 idiomas"
+			},
+			"gallery": {
+				"fileRequired": "Selecciona un archivo de imagen",
+				"fileInvalidType": "Selecciona una imagen JPEG, PNG, GIF o WebP",
+				"fileTooLarge": "El tamaño del archivo debe ser de 10 MB o menos",
+				"titleJaRequired": "Introduce un título en japonés",
+				"titleJaTooLong": "El título en japonés debe tener 200 caracteres o menos",
+				"titleEnRequired": "Introduce un título en inglés",
+				"titleEnTooLong": "El título en inglés debe tener 200 caracteres o menos",
+				"descriptionJaTooLong": "La descripción en japonés debe tener 1000 caracteres o menos",
+				"descriptionEnTooLong": "La descripción en inglés debe tener 1000 caracteres o menos",
+				"latitudeInvalid": "La latitud debe estar entre -90 y 90",
+				"longitudeInvalid": "La longitud debe estar entre -180 y 180",
+				"coordinatesRequired": "Introduce las coordenadas",
+				"takenAtInvalid": "Selecciona una fecha y hora válidas"
+			},
+			"pagination": {
+				"pagePositive": "El número de página debe ser un entero positivo",
+				"limitRange": "El límite debe estar entre 1 y 100"
+			},
+			"common": {
+				"languageInvalid": "Selecciona japonés, inglés o español",
+				"statusInvalid": "Estado no válido",
+				"slugRequired": "Introduce un slug",
+				"slugTooLong": "El slug debe tener 100 caracteres o menos",
+				"slugInvalid": "El slug debe empezar por una letra minúscula o un número, con guiones simples entre palabras",
+				"emailInvalid": "Introduce una dirección de correo electrónico válida",
+				"datetimeInvalid": "Introduce un formato de fecha y hora válido",
+				"idPositive": "El ID debe ser un entero positivo"
+			}
+		}
+	},
+	"Privacy": {
+		"title": "Política de privacidad",
+		"introduction": {
+			"title": "Introducción",
+			"content": "saneatsu.me (el «Sitio») es un sitio web personal que ofrece artículos técnicos y contenido de blog. El Sitio no recopila ninguna información personal de los usuarios (incluidas direcciones de correo electrónico, nombres o fotos de perfil)."
+		},
+		"thirdParty": {
+			"title": "Servicios de terceros",
+			"content": "El Sitio utiliza Google Analytics para el análisis de accesos. Google Analytics usa cookies para recopilar datos sobre el comportamiento de los visitantes de forma no identificable personalmente. Para obtener información sobre los datos recopilados y cómo se utilizan, consulta la Política de Privacidad de Google."
+		},
+		"contact": {
+			"title": "Contacto",
+			"content": "Para consultas sobre esta Política de privacidad, contacta con saneatsu.wakana@gmail.com."
+		},
+		"changes": {
+			"title": "Cambios en esta política",
+			"content": "Esta Política de privacidad puede modificarse cuando sea necesario."
+		},
+		"lastUpdated": "Última actualización"
+	},
+	"Terms": {
+		"title": "Términos del servicio",
+		"acceptance": {
+			"title": "Aceptación de los términos",
+			"content": "Al utilizar saneatsu.me (el «Sitio»), se considera que has aceptado estos Términos del servicio."
+		},
+		"service": {
+			"title": "Descripción del servicio",
+			"content": "El Sitio es un sitio web personal que ofrece artículos técnicos y contenido de blog. Parte del contenido puede incluir traducciones asistidas por IA o texto generado, y el Sitio no garantiza su exactitud. El contenido del servicio puede cambiar sin previo aviso."
+		},
+		"affiliate": {
+			"title": "Enlaces de afiliados y publicidad",
+			"content": "Este sitio participa en el Programa de Afiliados de Amazon, un programa de publicidad de afiliados diseñado para que los sitios puedan obtener comisiones publicitarias anunciando y enlazando a Amazon.co.jp. Si haces clic en un enlace de un artículo y realizas una compra, este sitio puede recibir una comisión de referencia. La existencia o no de una comisión de referencia no afecta al precio del producto. Es posible que en el futuro añadamos otros programas de afiliados o anuncios. Todos los artículos de este sitio pueden contener enlaces de afiliados, incluidos los de Amazon Afiliados."
+		},
+		"externalLinks": {
+			"title": "Enlaces externos",
+			"content": "Este sitio contiene enlaces a sitios web externos. El Sitio no asume ninguna responsabilidad por el contenido, los servicios o las transacciones de los sitios enlazados. Consulta la política de privacidad y los términos del servicio de cada sitio cuando utilices sitios externos."
+		},
+		"userObligations": {
+			"title": "Obligaciones del usuario",
+			"content": "Los usuarios deben cumplir lo siguiente al navegar por el Sitio y al enviar consultas u otra información:",
+			"items": {
+				"lawful": "No realizar actividades que infrinjan las leyes o el orden público y la moral",
+				"respectful": "No vulnerar los derechos ni la privacidad de otras personas",
+				"accurate": "Proporcionar información precisa y actualizada al enviar consultas o comentarios",
+				"security": "No realizar accesos no autorizados ni actividades que sobrecarguen el sistema"
+			}
+		},
+		"prohibited": {
+			"title": "Actividades prohibidas",
+			"content": "Se prohíben las siguientes actividades:",
+			"items": {
+				"illegal": "Actividades relacionadas con actos ilegales o delictivos",
+				"harmful": "Actividades que dañen la reputación o la credibilidad de otras personas",
+				"spam": "Spam u otras actividades molestas",
+				"unauthorized": "Uso comercial o reproducción no autorizados"
+			}
+		},
+		"intellectualProperty": {
+			"title": "Derechos de propiedad intelectual",
+			"content": "Los derechos de autor del contenido del Sitio (textos, imágenes, programas, etc.) pertenecen al Sitio o a sus legítimos titulares. Queda prohibida la copia, reproducción o modificación no autorizadas."
+		},
+		"disclaimer": {
+			"title": "Exención de responsabilidad",
+			"content": "El Sitio no garantiza la exactitud, integridad ni actualidad de la información proporcionada. Salvo en los casos en que la ley exija responsabilidad, el Sitio no se hace responsable de los daños derivados de su uso."
+		},
+		"limitation": {
+			"title": "Limitación de responsabilidad",
+			"content": "El Sitio no se hace responsable de los daños causados por la interrupción, suspensión, finalización, cambio o indisponibilidad del servicio, salvo que se deban a dolo o negligencia grave del Sitio."
+		},
+		"termination": {
+			"title": "Cese del uso",
+			"content": "Si un usuario infringe estos Términos, el Sitio podrá suspender el uso del servicio sin previo aviso."
+		},
+		"governing": {
+			"title": "Ley aplicable",
+			"content": "Estos Términos se rigen e interpretan de acuerdo con la legislación japonesa."
+		},
+		"changes": {
+			"title": "Cambios en los términos",
+			"content": "Estos Términos pueden modificarse cuando sea necesario. Los Términos actualizados entran en vigor cuando se publican en el Sitio. Los cambios importantes se comunicarán por medios razonables en el Sitio."
+		},
+		"contact": {
+			"title": "Contacto",
+			"content": "Para preguntas sobre estos Términos o sobre el funcionamiento del Sitio, contacta con saneatsu.wakana@gmail.com."
+		},
+		"lastUpdated": "Última actualización"
+	}
+}

--- a/packages/i18n/src/locales/index.ts
+++ b/packages/i18n/src/locales/index.ts
@@ -3,4 +3,5 @@
  */
 
 export { default as en } from "./en.json";
+export { default as es } from "./es.json";
 export { default as ja } from "./ja.json";

--- a/packages/i18n/src/locales/ja.json
+++ b/packages/i18n/src/locales/ja.json
@@ -16,12 +16,14 @@
 	"language": {
 		"japanese": "日本語",
 		"english": "English",
+		"spanish": "Español",
 		"switch": "言語を切り替え"
 	},
 	"LocaleSwitcher": {
 		"label": "言語を切り替え",
 		"ja": "日本語",
-		"en": "English"
+		"en": "English",
+		"es": "Español"
 	},
 	"home": {
 		"hero": {

--- a/packages/schemas/src/common.ts
+++ b/packages/schemas/src/common.ts
@@ -8,7 +8,7 @@ import { SLUG_REGEX } from "./slug";
  */
 
 /** 言語コード */
-export const languageSchema = z.enum(["ja", "en"], {
+export const languageSchema = z.enum(["ja", "en", "es"], {
 	error: () => i18nMessage("validation.custom.common.languageInvalid"),
 });
 


### PR DESCRIPTION
## 概要

このブランチには以下の変更が含まれます。

### 1. デフォルトフォールバックロケールを ja → en に変更（破壊的変更）
- ブラウザ言語が未対応・不明な場合のフォールバック先を日本語(ja)から英語(en)に変更
- middleware テストスイートの復旧と CI 実行の整備

### 2. スペイン語 (es) の全面追加
- i18n の `locales` に `es` を追加（`config.ts` を単一ソースに、routing/middleware まで自動伝播）
- `es.json` を新規作成（en と完全キー一致）、両言語スイッチャー・hreflang・RSS に es を追加
- 日付/OG のロケール整形を共有マップ（`bcp47ByLocale` / `openGraphLocaleByLocale`）に集約し、es が en にフォールバックするバグを解消
- DB の翻訳テーブル 3 種の `language` enum に `es` を追加（SQLite の text enum のため SQL マイグレーションは不要）
- 記事・ギャラリー・タグの Gemini 自動翻訳を ja→en に加えて ja→es も生成
- フロントの `LanguageCode` を i18n の `Locale` に統一し、`"ja" | "en"` 直書きを es 込みに拡張

### 3. 既存コンテンツ用バックフィル＋対象言語の単一ソース化
- `TARGET_LANGUAGES` を「翻訳できる言語」の単一ソース・オブ・トゥルースとし、自動翻訳・バックフィルを全てそこから導出
- 汎用バックフィルスクリプト `db:backfill`（`--target <locale>` / `--dry-run` / `--limit` 対応、冪等）を追加
- 将来の言語追加（例: ko）はタプル1行＋設定追加で済み、ハンドラ・スクリプトは無改修

### 4. ドキュメント
- `apps/docs/docs/deployment/i18n-translations.md` に、デプロイでの反映方法・既存コンテンツのバックフィル手順・新言語追加チェックリストを追加

## 破壊的変更

- **BREAKING CHANGE**: 既定のフォールバックロケールが `ja` から `en` に変わります。

## テスト計画

- [x] `pnpm type-check` / `pnpm check`（biome）がパス
- [x] backend 345 / frontend 625 / middleware 17 テストがパス
- [x] ローカル Turso に対し `db:backfill` の dry-run・実書き込み・冪等性（再実行で既存除外）を確認
- [ ] preview 環境で `/en`・`/es`・`/ja` の各ページと言語切り替えを確認
- [ ] （マージ後の手動作業）本番 Turso に対し `pnpm --filter @saneatsu/backend db:backfill` を実行し、既存コンテンツの es 翻訳を反映（未実行だと `/es/blog/[slug]` が 404 のまま）

🤖 Generated with [Claude Code](https://claude.ai/code)
