### PR TITLE
fix(api): Show Spanish tag names and harden Gemini output

### DIFF
--- a/apps/backend/src/lib/translate/translate-with-gemini.test.ts
+++ b/apps/backend/src/lib/translate/translate-with-gemini.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { stripLeadingLanguageLabel } from "./translate-with-gemini";
+
+/**
+ * stripLeadingLanguageLabel のテスト観点表（等価分割・境界値）
+ *
+ * | # | 観点                                   | 入力                         | 期待結果               |
+ * |---|----------------------------------------|------------------------------|------------------------|
+ * | 1 | "SPANISH:" + 改行（実際の混入ケース）  | "SPANISH:\nOrganización..."  | "Organización..."      |
+ * | 2 | "ENGLISH: " + スペース                 | "ENGLISH: Hello"             | "Hello"                |
+ * | 3 | 全角コロン "ESPAÑOL："                  | "ESPAÑOL：Hola"              | "Hola"                 |
+ * | 4 | ラベル無し（正常系・素通り）           | "Organización de ideas"      | "Organización de ideas"|
+ * | 5 | 未知ラベル "Nota:"（過剰除去しない）   | "Nota: algo importante"      | "Nota: algo importante"|
+ * | 6 | 前後の空白のみ（トリムされる）         | "  Hola  "                   | "Hola"                 |
+ * | 7 | 途中に出現するラベルは除去しない       | "Texto SPANISH: x"           | "Texto SPANISH: x"     |
+ */
+
+describe("stripLeadingLanguageLabel", () => {
+	describe("Unit Test", () => {
+		it("removes a leading 'SPANISH:' label followed by a newline", () => {
+			// Given: 実際に混入した形（言語ラベル + 改行 + 訳文）
+			// When: ラベル除去
+			const result = stripLeadingLanguageLabel(
+				"SPANISH:\nOrganización de ideas"
+			);
+			// Then: ラベルと前後空白が除去される
+			expect(result).toBe("Organización de ideas");
+		});
+
+		it("removes a leading 'ENGLISH:' label followed by a space", () => {
+			// Given / When
+			const result = stripLeadingLanguageLabel("ENGLISH: Hello world");
+			// Then
+			expect(result).toBe("Hello world");
+		});
+
+		it("removes a leading label with a full-width colon", () => {
+			// Given: 全角コロンのケース
+			// When
+			const result = stripLeadingLanguageLabel("ESPAÑOL：Hola");
+			// Then
+			expect(result).toBe("Hola");
+		});
+
+		it("leaves text without a language label unchanged", () => {
+			// Given: ラベルの無い正常な訳文
+			// When
+			const result = stripLeadingLanguageLabel("Organización de ideas");
+			// Then: そのまま返る
+			expect(result).toBe("Organización de ideas");
+		});
+
+		it("does NOT strip an unknown prefix like 'Nota:'", () => {
+			// Given: 言語ラベルではない正当な接頭辞
+			// When
+			const result = stripLeadingLanguageLabel("Nota: algo importante");
+			// Then: 過剰除去せずそのまま返る
+			expect(result).toBe("Nota: algo importante");
+		});
+
+		it("trims surrounding whitespace", () => {
+			// Given: 前後に空白のみ
+			// When
+			const result = stripLeadingLanguageLabel("  Hola  ");
+			// Then
+			expect(result).toBe("Hola");
+		});
+
+		it("does NOT strip a language label that appears mid-text", () => {
+			// Given: 先頭以外に現れるラベル
+			// When
+			const result = stripLeadingLanguageLabel("Texto SPANISH: x");
+			// Then: 先頭ではないので除去されない
+			expect(result).toBe("Texto SPANISH: x");
+		});
+	});
+});

--- a/apps/backend/src/lib/translate/translate-with-gemini.ts
+++ b/apps/backend/src/lib/translate/translate-with-gemini.ts
@@ -19,6 +19,26 @@ const SYSTEM_INSTRUCTION_BY_LANGUAGE: Record<TargetLanguage, string> = {
 };
 
 /**
+ * 先頭に付いた既知の言語ラベルを取り除く
+ *
+ * @description
+ * Gemini はシステムプロンプトで「訳文のみ返す」よう指示していても、稀に
+ * `SPANISH:\n訳文` のように言語ラベルを先頭に付けて返すことがある
+ * （実際にタグ翻訳で `SPANISH:\nOrganización de ideas` が混入した）。
+ * このラベルがそのまま DB に保存されるのを防ぐため、**既知の言語ラベルのみ**を除去する。
+ * `Nota:` のような正当な本文の接頭辞を巻き込まないよう、対象ラベルは限定する。
+ *
+ * @param text - Gemini から返った訳文
+ * @returns 先頭ラベルを除去しトリムした訳文
+ */
+export function stripLeadingLanguageLabel(text: string): string {
+	// 例: "SPANISH:", "ESPAÑOL:", "ENGLISH:", "日本語:" など（英語/スペイン語表記の言語名）
+	const leadingLanguageLabel =
+		/^\s*(?:spanish|english|español|inglés|japanese|japonés)\s*[:：]\s*/i;
+	return text.replace(leadingLanguageLabel, "").trim();
+}
+
+/**
  * Geminiで日本語から指定言語に翻訳
  *
  * @description
@@ -77,7 +97,8 @@ export async function translateWithGemini(
 			throw new Error("Translation result is empty");
 		}
 
-		return translatedText.trim();
+		// Gemini が稀に付ける先頭の言語ラベル（例: "SPANISH:"）を除去してから返す
+		return stripLeadingLanguageLabel(translatedText);
 	} catch (error) {
 		console.error("Gemini translation error:", error);
 		throw new Error(

--- a/apps/backend/src/routes/articles/handlers/get-all-articles/get-all-articles.openapi.ts
+++ b/apps/backend/src/routes/articles/handlers/get-all-articles/get-all-articles.openapi.ts
@@ -74,6 +74,10 @@ const TagSchema = z.object({
 			example: "TypeScript",
 			description: "英語のタグ名",
 		}),
+		es: z.string().openapi({
+			example: "TypeScript",
+			description: "スペイン語のタグ名",
+		}),
 	}),
 });
 

--- a/apps/backend/src/routes/articles/handlers/get-all-articles/get-all-articles.ts
+++ b/apps/backend/src/routes/articles/handlers/get-all-articles/get-all-articles.ts
@@ -183,7 +183,7 @@ export const getAllArticles: Handler = async (c) => {
 					createdAt: string;
 					updatedAt: string;
 					articleCount: number;
-					translations: { ja: string; en: string };
+					translations: { ja: string; en: string; es: string };
 				}
 			>();
 
@@ -195,7 +195,7 @@ export const getAllArticles: Handler = async (c) => {
 						createdAt: tagData.tagCreatedAt,
 						updatedAt: tagData.tagUpdatedAt,
 						articleCount: 0,
-						translations: { ja: "", en: "" },
+						translations: { ja: "", en: "", es: "" },
 					});
 				}
 
@@ -205,6 +205,8 @@ export const getAllArticles: Handler = async (c) => {
 					tag.translations.ja = tagData.tagName;
 				} else if (tagData.tagLanguage === "en") {
 					tag.translations.en = tagData.tagName;
+				} else if (tagData.tagLanguage === "es") {
+					tag.translations.es = tagData.tagName;
 				}
 			}
 

--- a/apps/backend/src/routes/articles/handlers/get-article/get-article.openapi.ts
+++ b/apps/backend/src/routes/articles/handlers/get-article/get-article.openapi.ts
@@ -72,6 +72,10 @@ const ArticleSchema = z.object({
 						example: "TypeScript",
 						description: "英語のタグ名",
 					}),
+					es: z.string().openapi({
+						example: "TypeScript",
+						description: "スペイン語のタグ名",
+					}),
 				}),
 			})
 		)

--- a/apps/backend/src/routes/articles/handlers/get-article/get-article.test.ts
+++ b/apps/backend/src/routes/articles/handlers/get-article/get-article.test.ts
@@ -164,7 +164,7 @@ describe("GET /articles/:slug - 記事詳細取得", () => {
 						createdAt: "2024-01-01T00:00:00.000Z",
 						updatedAt: "2024-01-01T00:00:00.000Z",
 						articleCount: 0,
-						translations: { ja: "TypeScript", en: "TypeScript" },
+						translations: { ja: "TypeScript", en: "TypeScript", es: "" },
 					},
 					{
 						id: 2,
@@ -172,7 +172,7 @@ describe("GET /articles/:slug - 記事詳細取得", () => {
 						createdAt: "2024-01-01T00:00:00.000Z",
 						updatedAt: "2024-01-01T00:00:00.000Z",
 						articleCount: 0,
-						translations: { ja: "Next.js", en: "Next.js" },
+						translations: { ja: "Next.js", en: "Next.js", es: "" },
 					},
 				],
 			},
@@ -325,7 +325,7 @@ describe("GET /articles/:slug - 記事詳細取得", () => {
 				createdAt: "2024-01-01T00:00:00.000Z",
 				updatedAt: "2024-01-01T00:00:00.000Z",
 				articleCount: 0,
-				translations: { ja: "TypeScript", en: "TypeScript" },
+				translations: { ja: "TypeScript", en: "TypeScript", es: "" },
 			},
 		]);
 	});
@@ -556,7 +556,7 @@ describe("GET /articles/:slug - 記事詳細取得", () => {
 				createdAt: "2024-01-01T00:00:00.000Z",
 				updatedAt: "2024-01-01T00:00:00.000Z",
 				articleCount: 0,
-				translations: { ja: "TypeScript", en: "TypeScript" },
+				translations: { ja: "TypeScript", en: "TypeScript", es: "" },
 			},
 			{
 				id: 2,
@@ -564,7 +564,7 @@ describe("GET /articles/:slug - 記事詳細取得", () => {
 				createdAt: "2024-01-01T00:00:00.000Z",
 				updatedAt: "2024-01-01T00:00:00.000Z",
 				articleCount: 0,
-				translations: { ja: "Next.js", en: "Next.js" },
+				translations: { ja: "Next.js", en: "Next.js", es: "" },
 			},
 		]);
 		expect(mockDb.update).toHaveBeenCalled(); // updateが呼ばれたことを確認

--- a/apps/backend/src/routes/articles/handlers/get-article/get-article.ts
+++ b/apps/backend/src/routes/articles/handlers/get-article/get-article.ts
@@ -158,7 +158,7 @@ export const getArticle: Handler = async (c) => {
 				createdAt: string;
 				updatedAt: string;
 				articleCount: number;
-				translations: { ja: string; en: string };
+				translations: { ja: string; en: string; es: string };
 			}
 		>();
 
@@ -170,7 +170,7 @@ export const getArticle: Handler = async (c) => {
 					createdAt: tagData.tagCreatedAt,
 					updatedAt: tagData.tagUpdatedAt,
 					articleCount: 0,
-					translations: { ja: "", en: "" },
+					translations: { ja: "", en: "", es: "" },
 				});
 			}
 
@@ -180,6 +180,8 @@ export const getArticle: Handler = async (c) => {
 				tag.translations.ja = tagData.tagName;
 			} else if (tagData.tagLanguage === "en") {
 				tag.translations.en = tagData.tagName;
+			} else if (tagData.tagLanguage === "es") {
+				tag.translations.es = tagData.tagName;
 			}
 		}
 

--- a/apps/backend/src/routes/articles/handlers/get-related-articles/get-related-articles.openapi.ts
+++ b/apps/backend/src/routes/articles/handlers/get-related-articles/get-related-articles.openapi.ts
@@ -47,6 +47,10 @@ const TagSchema = z.object({
 			example: "TypeScript",
 			description: "英語のタグ名",
 		}),
+		es: z.string().openapi({
+			example: "TypeScript",
+			description: "スペイン語のタグ名",
+		}),
 	}),
 });
 

--- a/apps/backend/src/routes/articles/handlers/get-related-articles/get-related-articles.ts
+++ b/apps/backend/src/routes/articles/handlers/get-related-articles/get-related-articles.ts
@@ -106,7 +106,7 @@ export const getRelatedArticles: Handler = async (c) => {
 				createdAt: string;
 				updatedAt: string;
 				articleCount: number;
-				translations: { ja: string; en: string };
+				translations: { ja: string; en: string; es: string };
 			}>;
 		}> = [];
 
@@ -202,7 +202,7 @@ export const getRelatedArticles: Handler = async (c) => {
 								createdAt: string;
 								updatedAt: string;
 								articleCount: number;
-								translations: { ja: string; en: string };
+								translations: { ja: string; en: string; es: string };
 							}
 						>();
 
@@ -214,7 +214,7 @@ export const getRelatedArticles: Handler = async (c) => {
 									createdAt: tagData.tagCreatedAt,
 									updatedAt: tagData.tagUpdatedAt,
 									articleCount: 0,
-									translations: { ja: "", en: "" },
+									translations: { ja: "", en: "", es: "" },
 								});
 							}
 
@@ -224,6 +224,8 @@ export const getRelatedArticles: Handler = async (c) => {
 								tag.translations.ja = tagData.tagName;
 							} else if (tagData.tagLanguage === "en") {
 								tag.translations.en = tagData.tagName;
+							} else if (tagData.tagLanguage === "es") {
+								tag.translations.es = tagData.tagName;
 							}
 						}
 
@@ -342,7 +344,7 @@ export const getRelatedArticles: Handler = async (c) => {
 						createdAt: string;
 						updatedAt: string;
 						articleCount: number;
-						translations: { ja: string; en: string };
+						translations: { ja: string; en: string; es: string };
 					}
 				>();
 
@@ -354,7 +356,7 @@ export const getRelatedArticles: Handler = async (c) => {
 							createdAt: tagData.tagCreatedAt,
 							updatedAt: tagData.tagUpdatedAt,
 							articleCount: 0,
-							translations: { ja: "", en: "" },
+							translations: { ja: "", en: "", es: "" },
 						});
 					}
 
@@ -364,6 +366,8 @@ export const getRelatedArticles: Handler = async (c) => {
 						tag.translations.ja = tagData.tagName;
 					} else if (tagData.tagLanguage === "en") {
 						tag.translations.en = tagData.tagName;
+					} else if (tagData.tagLanguage === "es") {
+						tag.translations.es = tagData.tagName;
 					}
 				}
 

--- a/apps/backend/src/routes/dashboard/handlers/get-overview/get-overview.openapi.ts
+++ b/apps/backend/src/routes/dashboard/handlers/get-overview/get-overview.openapi.ts
@@ -42,6 +42,7 @@ const popularArticleTagOpenApiSchema = z.object({
 	translations: z.object({
 		ja: z.string(),
 		en: z.string(),
+		es: z.string(),
 	}),
 });
 

--- a/apps/backend/src/routes/dashboard/handlers/get-overview/get-overview.ts
+++ b/apps/backend/src/routes/dashboard/handlers/get-overview/get-overview.ts
@@ -162,7 +162,7 @@ export const getDashboardOverview: Handler = async (c) => {
 				number,
 				{
 					id: number;
-					translations: { ja: string; en: string };
+					translations: { ja: string; en: string; es: string };
 				}
 			>();
 
@@ -170,7 +170,7 @@ export const getDashboardOverview: Handler = async (c) => {
 				if (!tagsMap.has(tagData.tagId)) {
 					tagsMap.set(tagData.tagId, {
 						id: tagData.tagId,
-						translations: { ja: "", en: "" },
+						translations: { ja: "", en: "", es: "" },
 					});
 				}
 
@@ -180,6 +180,8 @@ export const getDashboardOverview: Handler = async (c) => {
 					tag.translations.ja = tagData.tagName;
 				} else if (tagData.tagLanguage === "en") {
 					tag.translations.en = tagData.tagName;
+				} else if (tagData.tagLanguage === "es") {
+					tag.translations.es = tagData.tagName;
 				}
 			}
 

--- a/apps/backend/src/routes/dashboard/handlers/get-stats/get-stats.ts
+++ b/apps/backend/src/routes/dashboard/handlers/get-stats/get-stats.ts
@@ -154,7 +154,7 @@ export const getDashboardStats: Handler = async (c) => {
 				number,
 				{
 					id: number;
-					translations: { ja: string; en: string };
+					translations: { ja: string; en: string; es: string };
 				}
 			>();
 
@@ -162,7 +162,7 @@ export const getDashboardStats: Handler = async (c) => {
 				if (!tagsMap.has(tagData.tagId)) {
 					tagsMap.set(tagData.tagId, {
 						id: tagData.tagId,
-						translations: { ja: "", en: "" },
+						translations: { ja: "", en: "", es: "" },
 					});
 				}
 
@@ -172,6 +172,8 @@ export const getDashboardStats: Handler = async (c) => {
 					tag.translations.ja = tagData.tagName;
 				} else if (tagData.tagLanguage === "en") {
 					tag.translations.en = tagData.tagName;
+				} else if (tagData.tagLanguage === "es") {
+					tag.translations.es = tagData.tagName;
 				}
 			}
 

--- a/apps/backend/src/routes/tags/handlers/get-all-tags/get-all-tags.openapi.ts
+++ b/apps/backend/src/routes/tags/handlers/get-all-tags/get-all-tags.openapi.ts
@@ -34,6 +34,10 @@ const TagSchema = z.object({
 				example: "TypeScript",
 				description: "英語の翻訳",
 			}),
+			es: z.string().nullable().openapi({
+				example: "TypeScript",
+				description: "スペイン語の翻訳",
+			}),
 		})
 		.openapi({
 			description: "タグの翻訳データ",

--- a/apps/backend/src/routes/tags/handlers/get-all-tags/get-all-tags.test.ts
+++ b/apps/backend/src/routes/tags/handlers/get-all-tags/get-all-tags.test.ts
@@ -84,11 +84,11 @@ describe("GET /tags - タグ一覧取得", () => {
 			expect(data.data).toHaveLength(2);
 			expect(data.data[0]).toEqual({
 				...mockTags[0],
-				translations: { ja: null, en: null },
+				translations: { ja: null, en: null, es: null },
 			});
 			expect(data.data[1]).toEqual({
 				...mockTags[1],
-				translations: { ja: null, en: null },
+				translations: { ja: null, en: null, es: null },
 			});
 			expect(data.data[0].articleCount).toBe(5);
 			expect(data.data[1].articleCount).toBe(3);
@@ -411,6 +411,7 @@ describe("GET /tags - タグ一覧取得", () => {
 				translations: {
 					ja: "タイプスクリプト",
 					en: "TypeScript",
+					es: null,
 				},
 			});
 			expect(data.data[1]).toEqual({
@@ -418,6 +419,7 @@ describe("GET /tags - タグ一覧取得", () => {
 				translations: {
 					ja: "ジャバスクリプト",
 					en: "JavaScript",
+					es: null,
 				},
 			});
 		});
@@ -501,6 +503,7 @@ describe("GET /tags - タグ一覧取得", () => {
 				translations: {
 					ja: "タイプスクリプト",
 					en: "TypeScript",
+					es: null,
 				},
 			});
 			expect(data.data[1]).toEqual({
@@ -508,6 +511,7 @@ describe("GET /tags - タグ一覧取得", () => {
 				translations: {
 					ja: null,
 					en: null,
+					es: null,
 				},
 			});
 		});

--- a/apps/backend/src/routes/tags/handlers/get-all-tags/get-all-tags.ts
+++ b/apps/backend/src/routes/tags/handlers/get-all-tags/get-all-tags.ts
@@ -85,6 +85,9 @@ export const getAllTags: Handler = async (c) => {
 					en:
 						tagTranslationsForTag.find((t) => t.language === "en")?.name ??
 						null,
+					es:
+						tagTranslationsForTag.find((t) => t.language === "es")?.name ??
+						null,
 				},
 			};
 		});

--- a/apps/backend/src/routes/tags/handlers/update-tag/update-tag.openapi.ts
+++ b/apps/backend/src/routes/tags/handlers/update-tag/update-tag.openapi.ts
@@ -37,6 +37,16 @@ const TagUpdateSchema = z.object({
 			example: "TypeScript",
 			description: "タグの表示名（英語）。未指定の場合は自動翻訳されます。",
 		}),
+	esName: z
+		.string()
+		.min(1, "スペイン語のタグ名は1文字以上である必要があります")
+		.max(100, "スペイン語のタグ名は100文字以内で入力してください")
+		.optional()
+		.openapi({
+			example: "TypeScript",
+			description:
+				"タグの表示名（スペイン語）。未指定の場合は自動翻訳されます。",
+		}),
 	slug: z
 		.string()
 		.min(1, "スラッグは必須です")

--- a/apps/backend/src/routes/tags/handlers/update-tag/update-tag.test.ts
+++ b/apps/backend/src/routes/tags/handlers/update-tag/update-tag.test.ts
@@ -11,6 +11,12 @@ vi.mock("@/services/gemini-translation/gemini-translation", () => ({
 	})),
 }));
 
+// スペイン語自動翻訳（translateWithGemini）のモック
+const mockTranslateWithGemini = vi.fn();
+vi.mock("@/lib/translate", () => ({
+	translateWithGemini: (...args: unknown[]) => mockTranslateWithGemini(...args),
+}));
+
 // getDatabase関数のモック
 vi.mock("@/lib/database", () => ({
 	getDatabase: vi.fn(),
@@ -107,6 +113,152 @@ describe("PUT /tags/:id - タグ更新", () => {
 			expect(data).toEqual({
 				data: mockUpdatedTag,
 				message: "タグが正常に更新されました",
+			});
+		});
+
+		it("esNameを指定すると既存のスペイン語翻訳をUPDATEする", async () => {
+			// Arrange
+			const { mockDb } = setupDbMocks();
+			const { getDatabase } = await import("@/lib/database");
+			(getDatabase as any).mockResolvedValue({
+				createDatabaseClient: vi.fn().mockReturnValue(mockDb),
+				tags: {},
+				tagTranslations: {},
+			});
+
+			const mockUpdatedTag = {
+				id: 1,
+				slug: "typescript",
+				createdAt: "2024-01-01T00:00:00.000Z",
+				updatedAt: "2024-01-02T00:00:00.000Z",
+			};
+
+			const chain = <T>(value: T) => ({
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockReturnValue({
+						limit: vi.fn().mockResolvedValue(value),
+					}),
+				}),
+			});
+
+			mockDb.select
+				.mockReturnValueOnce(chain([{ id: 1, slug: "javascript" }])) // 既存タグ確認
+				.mockReturnValueOnce(chain([])) // スラッグ重複チェック（重複なし）
+				.mockReturnValueOnce(chain([{ id: 99 }])); // 既存のes翻訳あり
+
+			const esUpdateMock = {
+				set: vi.fn().mockReturnValue({
+					where: vi.fn().mockResolvedValue(undefined),
+				}),
+			};
+			mockDb.update
+				.mockReturnValueOnce({
+					set: vi.fn().mockReturnValue({
+						where: vi.fn().mockReturnValue({
+							returning: vi.fn().mockResolvedValue([mockUpdatedTag]),
+						}),
+					}),
+				}) // タグ更新
+				.mockReturnValueOnce({
+					set: vi.fn().mockReturnValue({
+						where: vi.fn().mockResolvedValue(undefined),
+					}),
+				}) // 日本語翻訳更新
+				.mockReturnValueOnce(esUpdateMock); // スペイン語翻訳更新（既存行のUPDATE）
+
+			// Act
+			const client = testClient(tagsRoute, {
+				TURSO_DATABASE_URL: "test://test.db",
+				TURSO_AUTH_TOKEN: "test-token",
+			}) as any;
+			const res = await client[":id"].$put({
+				param: { id: "1" },
+				json: {
+					name: "タイプスクリプト",
+					esName: "Mecanografiado",
+					slug: "typescript",
+				},
+			});
+
+			// Assert
+			expect(res.status).toBe(200);
+			// 既存es行がある場合はINSERTせずUPDATEされる
+			expect(esUpdateMock.set).toHaveBeenCalledWith({ name: "Mecanografiado" });
+			expect(mockDb.insert).not.toHaveBeenCalled();
+			// esNameを指定したので自動翻訳は呼ばれない
+			expect(mockTranslateWithGemini).not.toHaveBeenCalled();
+		});
+
+		it("esNameを指定し既存のスペイン語翻訳が無い場合はINSERTする", async () => {
+			// Arrange
+			const { mockDb } = setupDbMocks();
+			const { getDatabase } = await import("@/lib/database");
+			(getDatabase as any).mockResolvedValue({
+				createDatabaseClient: vi.fn().mockReturnValue(mockDb),
+				tags: {},
+				tagTranslations: {},
+			});
+
+			const mockUpdatedTag = {
+				id: 1,
+				slug: "typescript",
+				createdAt: "2024-01-01T00:00:00.000Z",
+				updatedAt: "2024-01-02T00:00:00.000Z",
+			};
+
+			const chain = <T>(value: T) => ({
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockReturnValue({
+						limit: vi.fn().mockResolvedValue(value),
+					}),
+				}),
+			});
+
+			mockDb.select
+				.mockReturnValueOnce(chain([{ id: 1, slug: "javascript" }])) // 既存タグ確認
+				.mockReturnValueOnce(chain([])) // スラッグ重複チェック（重複なし）
+				.mockReturnValueOnce(chain([])); // 既存のes翻訳なし
+
+			mockDb.update
+				.mockReturnValueOnce({
+					set: vi.fn().mockReturnValue({
+						where: vi.fn().mockReturnValue({
+							returning: vi.fn().mockResolvedValue([mockUpdatedTag]),
+						}),
+					}),
+				}) // タグ更新
+				.mockReturnValueOnce({
+					set: vi.fn().mockReturnValue({
+						where: vi.fn().mockResolvedValue(undefined),
+					}),
+				}); // 日本語翻訳更新
+
+			const esInsertMock = {
+				values: vi.fn().mockResolvedValue(undefined),
+			};
+			mockDb.insert.mockReturnValueOnce(esInsertMock);
+
+			// Act
+			const client = testClient(tagsRoute, {
+				TURSO_DATABASE_URL: "test://test.db",
+				TURSO_AUTH_TOKEN: "test-token",
+			}) as any;
+			const res = await client[":id"].$put({
+				param: { id: "1" },
+				json: {
+					name: "タイプスクリプト",
+					esName: "Mecanografiado",
+					slug: "typescript",
+				},
+			});
+
+			// Assert
+			expect(res.status).toBe(200);
+			// 既存es行が無い場合はINSERTされる
+			expect(esInsertMock.values).toHaveBeenCalledWith({
+				tagId: 1,
+				language: "es",
+				name: "Mecanografiado",
 			});
 		});
 

--- a/apps/backend/src/routes/tags/handlers/update-tag/update-tag.ts
+++ b/apps/backend/src/routes/tags/handlers/update-tag/update-tag.ts
@@ -3,6 +3,7 @@ import { and, eq, not } from "drizzle-orm";
 
 import type { Env } from "@/env";
 import { getDatabase } from "@/lib";
+import { translateWithGemini } from "@/lib/translate";
 import { createTranslationService } from "@/services/gemini-translation/gemini-translation";
 
 import type { updateTagRoute } from "./update-tag.openapi";
@@ -33,7 +34,7 @@ export const updateTag: Handler = async (c) => {
 
 		// 2. パラメータとリクエストボディを取得
 		const { id } = c.req.valid("param");
-		const { name, enName, slug } = c.req.valid("json");
+		const { name, enName, esName, slug } = c.req.valid("json");
 
 		// 3. IDの検証
 		const tagId = Number.parseInt(id, 10);
@@ -158,6 +159,61 @@ export const updateTag: Handler = async (c) => {
 						eq(tagTranslations.language, "en")
 					)
 				);
+		}
+
+		// 8-2. スペイン語への翻訳を実行（手動指定または自動翻訳）
+		// enName と同様に、esName があればそれを使い、無ければ Gemini で自動翻訳する。
+		let spanishName: string | null = null;
+
+		if (esName) {
+			// 手動で提供されたスペイン語名を使用
+			spanishName = esName;
+		} else if (c.env.GEMINI_API_KEY) {
+			// スペイン語名が未指定の場合は自動翻訳（表示名なので自然な訳を得る translateWithGemini を使う）
+			try {
+				spanishName = await translateWithGemini(
+					name,
+					c.env.GEMINI_API_KEY,
+					"es"
+				);
+			} catch (error) {
+				// 翻訳エラーが発生してもメインの処理は続行
+				console.error(`Spanish translation error for tag ${tagId}:`, error);
+			}
+		}
+
+		// スペイン語名が取得できた場合のみ保存
+		// tag_translations には (tagId, language) のユニーク制約が無いため upsert は使えない。
+		// 既存の es 行があれば UPDATE、無ければ INSERT する。
+		if (spanishName) {
+			const existingEs = await db
+				.select({ id: tagTranslations.id })
+				.from(tagTranslations)
+				.where(
+					and(
+						eq(tagTranslations.tagId, tagId),
+						eq(tagTranslations.language, "es")
+					)
+				)
+				.limit(1);
+
+			if (existingEs.length > 0) {
+				await db
+					.update(tagTranslations)
+					.set({ name: spanishName })
+					.where(
+						and(
+							eq(tagTranslations.tagId, tagId),
+							eq(tagTranslations.language, "es")
+						)
+					);
+			} else {
+				await db.insert(tagTranslations).values({
+					tagId,
+					language: "es",
+					name: spanishName,
+				});
+			}
 		}
 
 		// 9. レスポンスを返す

--- a/apps/frontend/src/entities/tag/api/use-update-tag/use-update-tag.ts
+++ b/apps/frontend/src/entities/tag/api/use-update-tag/use-update-tag.ts
@@ -30,6 +30,7 @@ export function useUpdateTag() {
 				json: {
 					name: data.name,
 					enName: data.enName,
+					esName: data.esName,
 					slug: data.slug,
 				},
 			});

--- a/apps/frontend/src/entities/tag/ui/tag-badge/tag-badge.tsx
+++ b/apps/frontend/src/entities/tag/ui/tag-badge/tag-badge.tsx
@@ -30,8 +30,13 @@ export interface TagBadgeProps {
 export function TagBadge({ tag, className }: TagBadgeProps) {
 	const locale = useLocale() as "ja" | "en" | "es";
 
-	// ロケールに応じたタグ名を取得、なければslugをフォールバック
-	const tagName = tag.translations[locale] || tag.slug;
+	// ロケールに応じたタグ名を取得。未生成の言語では en → ja → slug の順にフォールバックする
+	// （例: es 訳が無いタグは英語名、それも無ければ日本語名、最後に slug）
+	const tagName =
+		tag.translations[locale] ||
+		tag.translations.en ||
+		tag.translations.ja ||
+		tag.slug;
 
 	return (
 		<Badge variant="outline" className={className}>

--- a/apps/frontend/src/features/tag-management/ui/tag-update-form/tag-update-form.test.tsx
+++ b/apps/frontend/src/features/tag-management/ui/tag-update-form/tag-update-form.test.tsx
@@ -261,5 +261,27 @@ describe("TagUpdateForm", () => {
 				expect(toast.success).toHaveBeenCalled();
 			});
 		});
+
+		describe("スペイン語タグ名", () => {
+			it("スペイン語名を入力して送信するとesNameが渡される", async () => {
+				// Given: フォームをレンダリングし、スペイン語欄に入力
+				const user = userEvent.setup();
+				render(<TagUpdateForm tag={mockTag} />, { wrapper });
+
+				const esInput = screen.getByLabelText("タグ名（スペイン語）");
+				await user.type(esInput, "Mecanografiado");
+
+				// When: フォームを送信
+				const submitButton = screen.getByRole("button", { name: "更新" });
+				await user.click(submitButton);
+
+				// Then: mutation に esName が含まれる
+				await waitFor(() => {
+					expect(mockMutateAsync).toHaveBeenCalledWith(
+						expect.objectContaining({ esName: "Mecanografiado" })
+					);
+				});
+			});
+		});
 	});
 });

--- a/apps/frontend/src/features/tag-management/ui/tag-update-form/tag-update-form.tsx
+++ b/apps/frontend/src/features/tag-management/ui/tag-update-form/tag-update-form.tsx
@@ -39,6 +39,12 @@ const tagUpdateSchema = z.object({
 		.max(100, "英語のタグ名は100文字以内で入力してください")
 		.optional()
 		.or(z.literal("")),
+	esName: z
+		.string()
+		.min(1, "スペイン語のタグ名は1文字以上である必要があります")
+		.max(100, "スペイン語のタグ名は100文字以内で入力してください")
+		.optional()
+		.or(z.literal("")),
 	slug: z
 		.string()
 		.min(1, "スラッグは必須です")
@@ -76,6 +82,7 @@ export function TagUpdateForm({ tag }: TagUpdateFormProps) {
 		defaultValues: {
 			name: tag.translations.ja ?? "",
 			enName: tag.translations.en ?? "",
+			esName: tag.translations.es ?? "",
 			slug: tag.slug,
 		},
 	});
@@ -104,6 +111,7 @@ export function TagUpdateForm({ tag }: TagUpdateFormProps) {
 				id: tag.id,
 				name: data.name,
 				enName: data.enName || undefined,
+				esName: data.esName || undefined,
 				slug: data.slug,
 			});
 
@@ -131,6 +139,29 @@ export function TagUpdateForm({ tag }: TagUpdateFormProps) {
 							<p className="text-sm text-destructive mt-1">{formError}</p>
 						</div>
 					)}
+
+					{/* スラッグ（タグ名より上に配置） */}
+					<FormField
+						control={form.control}
+						name="slug"
+						render={({ field }) => (
+							<FormItem>
+								<FormLabel required>スラッグ</FormLabel>
+								<FormControl>
+									<Input
+										placeholder="typescript"
+										className="max-w-md"
+										{...field}
+									/>
+								</FormControl>
+								<FormDescription>
+									小文字英数字で始まり、単語をハイフンで区切る形式（例:
+									typescript, web-development）
+								</FormDescription>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
 
 					{/* タグ名（日本語） */}
 					<FormField
@@ -176,23 +207,22 @@ export function TagUpdateForm({ tag }: TagUpdateFormProps) {
 						)}
 					/>
 
-					{/* スラッグ */}
+					{/* タグ名（スペイン語） */}
 					<FormField
 						control={form.control}
-						name="slug"
+						name="esName"
 						render={({ field }) => (
 							<FormItem>
-								<FormLabel required>スラッグ</FormLabel>
+								<FormLabel>タグ名（スペイン語）</FormLabel>
 								<FormControl>
 									<Input
-										placeholder="typescript"
+										placeholder="TypeScript"
 										className="max-w-md"
 										{...field}
 									/>
 								</FormControl>
 								<FormDescription>
-									小文字英数字で始まり、単語をハイフンで区切る形式（例:
-									typescript, web-development）
+									スペイン語のタグ名を入力してください。未入力の場合は自動翻訳されます。
 								</FormDescription>
 								<FormMessage />
 							</FormItem>

--- a/apps/frontend/src/shared/model/tag.ts
+++ b/apps/frontend/src/shared/model/tag.ts
@@ -76,6 +76,8 @@ export interface TagUpdateRequest {
 	name: string;
 	/** 英語のタグ名（1-100文字、オプショナル。未指定の場合は自動翻訳） */
 	enName?: string;
+	/** スペイン語のタグ名（1-100文字、オプショナル。未指定の場合は自動翻訳） */
+	esName?: string;
 	/** タグのスラッグ（小文字英数字で始まり、単語をハイフンで区切る形式、1-100文字） */
 	slug: string;
 }

--- a/packages/schemas/src/dashboard.ts
+++ b/packages/schemas/src/dashboard.ts
@@ -29,6 +29,7 @@ export const popularArticleTagSchema = z.object({
 	translations: z.object({
 		ja: z.string(),
 		en: z.string(),
+		es: z.string(),
 	}),
 });
 


### PR DESCRIPTION
## 概要

本番へ es バックフィルを実行した後に見つかった、タグの多言語対応まわりの3課題を修正する。

### 1. Gemini ラベル混入の再発防止 (`fix(api)`)
- `translateWithGemini`（ギャラリー・タグで使用）が稀に `SPANISH:\n...` のようなラベルを先頭に付けて返し、そのまま DB に保存されていた（実際にタグが `SPANISH:\nOrganización de ideas` として保存された）。
- `stripLeadingLanguageLabel` を追加し、**既知の言語ラベルのみ**を先頭から除去する（`Nota:` のような正当な接頭辞は残す）。

### 2. es のタグ名が slug にフォールバックする不具合の根治 (`fix(api)`)
- `/es` の記事カードでタグが英語 slug（work/diary 等）で表示されていた。DB に es タグ訳は存在するのに、**API がタグ翻訳を `{ ja, en }` 決め打ちで組み立てて es を捨てていた**のが原因。
- 記事・タグ・ダッシュボードの各ハンドラとレスポンススキーマに es を追加。`TagBadge` のフォールバックを `es → en → ja → slug` に改善。

### 3. タグ編集フォームの改善 (`feat(ui)`)
- `/admin/tags/[id]/edit` に**スペイン語のタグ名入力欄**を追加し、**スラッグ欄をタグ名の上へ移動**（順: スラッグ → 日本語 → 英語 → スペイン語）。
- `update-tag` が es を永続化（手動入力があればそれを、無ければ日本語から自動翻訳）。`tag_translations` に `(tagId, language)` のユニーク制約が無いため、既存 es 行の有無を見て UPDATE / INSERT する。

## テスト計画

- [x] `pnpm type-check` / `pnpm check`（biome）がパス
- [x] backend 354 / frontend 626 テストがパス（ラベル除去・es タグ翻訳・es 永続化・フォーム送信の各テストを追加）
- [ ] preview 環境で `/es` の記事カードのタグがスペイン語表示になることを確認
- [ ] preview の `/admin/tags/[id]/edit` でスラッグが最上部・スペイン語欄が表示され、保存後に es 訳が反映されることを確認
- [ ] マージ→本番デプロイ後、`https://saneatsu.me/es` でタグがスペイン語表示になることを確認（本番 DB は既にバックフィル済み）

🤖 Generated with [Claude Code](https://claude.ai/code)
